### PR TITLE
Add IOErrorSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,24 @@
 ## Release a new version
 
 You can release a new version by creating a tag in all the assisted-installer repositories.
+
 1. Update the assited-installer.yaml with the relevant git hash.
 2. Build the docker image, locally
-```
+
+```bash
 make local-update
 ```
+
 3. Execute the release image
 
 ```shell script
 docker run -v $(pwd)/assisted-installer.yaml:/assisted-installer.yaml -v $HOME/.netrc:/root/.netrc -it assisted-installer-deployment:local -t <tag>
+```
+
+## Add new signature
+
+Run the following commands for more details:
+
+```bash
+./tools/add_triage_signature.py --help
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ beautifulsoup4>=4.9.3
 tabulate~=0.8.9
 python-dateutil~=2.8.1
 tqdm~=4.59.0
+colorlog~=4.7.2
+fuzzywuzzy~=0.18.0


### PR DESCRIPTION
The new signature downloads the cluster logs, and go over all the
hosts logs files searching for a 'dmesg' file.
Then, it looks for i/o errors substrings and groups them per host.

Adding a couple of new helper functions to be used -
- search_strings_in_file
- group_similar_strings
- get_host_id_for_host_tar
- extract_file_from_tar

Example of a signature output
```
id | hostname | log | similar_logs
-- | -- | -- | --
8e20225c-7859-63f8-916c-03f169bd3161 | len84 | [Wed Mar 3 14:54:56 2021] blk_update_request: I/O error, dev loop1, sector 229752 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0 | 10
8e20225c-7859-63f8-916c-03f169bd3161 | len84 | [Wed Mar 3 14:30:17 2021] usb 1-1.1: USB disconnect, device number 3 | 2
720e6550-970c-b3f8-d2d2-c52c5504702e | len81 | [Wed Mar 3 14:54:40 2021] blk_update_request: I/O error, dev loop1, sector 229752 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0 | 10
720e6550-970c-b3f8-d2d2-c52c5504702e | len81 | [Wed Mar 3 13:47:33 2021] usb 1-1.5: USB disconnect, device number 3 | 1
3da4e0e1-8c14-3eb7-17ec-35469f54b649 | len83 | [Wed Mar 3 14:28:12 2021] usb 1-1.1: USB disconnect, device number 3 | 1
2d89a499-0c28-53f7-f5f7-4da0b67ede67 | len80 | [Wed Mar 3 14:54:29 2021] blk_update_request: I/O error, dev loop1, sector 229752 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0 | 10
2d89a499-0c28-53f7-f5f7-4da0b67ede67 | len80 | [Wed Mar 3 13:47:20 2021] usb 1-1.5: USB disconnect, device number 3 | 1
1ba3f22c-f71a-bca8-9955-19452c2ff656 | len82 | [Wed Mar 3 14:55:22 2021] blk_update_request: I/O error, dev loop1, sector 229752 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0 | 10
1ba3f22c-f71a-bca8-9955-19452c2ff656 | len82 | [Wed Mar 3 13:47:08 2021] usb 1-1.5: USB disconnect, device number 3
```