### PR TITLE
signature: agent step failure - output only stderr

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -643,7 +643,6 @@ class AgentStepFailureSignature(Signature):
                     time=step_failure_log['time'],
                     exit_code=step_failure_message['exit_code'],
                     step_id=step_failure_message['step_id'],
-                    stdout=self._prepare_output(step_failure_message['stdout']),
                     stderr=self._prepare_output(step_failure_message['stderr']),
                 ))
 


### PR DESCRIPTION
As the relevant information for identifying a failure issue is mostly in stderr,
remove stdout column from table output for easier traversal.