### PR TITLE
supporting clusters with the old 'metdata.json' files

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -89,7 +89,14 @@ def get_metadata_json(cluster_url):
         res.raise_for_status()
         return res.json()
     except Exception as e:
-        raise FailedToGetMetadataException from e
+        logger.warning("Couldn't find new URL for 'metadata.json' file. "
+                       "Trying to access 'metdata.json'")
+        try:
+            res = requests.get("{}/metdata.json".format(cluster_url))
+            res.raise_for_status()
+            return res.json()
+        except Exception as e:
+            raise FailedToGetMetadataException from e
 
 
 @functools.lru_cache(maxsize=1000)


### PR DESCRIPTION
Not really tested, but that should try to access the old 'metdata.json' files if 'metadata.json' files are not existing.