### PR TITLE
Fix JIRA triage ticket version field for 4.8.0-fc.x versions

### DIFF
--- a/tools/create_triage_tickets.py
+++ b/tools/create_triage_tickets.py
@@ -79,9 +79,17 @@ def create_jira_ticket(jclient, existing_tickets, failure_id, cluster_md):
         return None
 
     url = "{}/files/{}".format(LOGS_COLLECTOR, failure_id)
+
+    raw_version = cluster_md['openshift_version']
+
+    if raw_version.startswith("4.8"):
+        # JIRA doesn't have an entry for 4.8.0-fc.0, so shorten it to 4.8
+        raw_version = "4.8"
+
+    ticket_affected_version_field = 'OpenShift {}'.format(raw_version)
     new_issue = jclient.create_issue(project="MGMT",
                                      summary=summary,
-                                     versions=[{'name': 'OpenShift {}'.format(cluster_md['openshift_version'])}],
+                                     versions=[{'name': ticket_affected_version_field}],
                                      components=[{'name': "Assisted-installer Triage"}],
                                      priority={'name': 'Blocker'},
                                      issuetype={'name': 'Bug'},


### PR DESCRIPTION
JIRA only has entries for `OpenShift 4.7`, `OpenShift 4.8`, etc. No
entry for `OpenShift 4.8.0-fc.x`.

See this failure http://assisted-jenkins.usersys.redhat.com/job/download_logs/17476/console

```
01:06:03  Traceback (most recent call last):
...
01:06:03    File "/mnt-assisted-log/workspace/download_logs/deploymentRepo/assisted-installer-deployment/./tools/create_triage_tickets.py", line 82, in create_jira_ticket
...
01:06:03  jira.exceptions.JIRAError: JiraError HTTP 400 url: https://issues.redhat.com/rest/api/2/issue
01:06:03  	text: Version name 'OpenShift 4.8.0-fc.0' is not valid
```