### PR TITLE
MGMT-4640 Renamed generate-ocp-version target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ reports/
 .eggs/
 *egg-info
 **/RCS/**
+.idea

--- a/tools/update_default_release_versions_to_latest.py
+++ b/tools/update_default_release_versions_to_latest.py
@@ -212,7 +212,7 @@ def commit_and_push_version_update_changes(message_prefix):
 
 def verify_latest_config():
     try:
-        cmd(["make", "generate-ocp-version"], cwd=ASSISTED_SERVICE_CLONE_DIR)
+        cmd(["make", "generate-configuration"], cwd=ASSISTED_SERVICE_CLONE_DIR)
     except subprocess.CalledProcessError as e:
         if e.returncode == 2:
             # We run the command just for its side-effects, we don't care if it fails

--- a/tools/update_ocp_versions.py
+++ b/tools/update_ocp_versions.py
@@ -164,7 +164,7 @@ def clone_assisted_service(github_user):
 
 def verify_latest_config():
     try:
-        cmd(["make", "generate-ocp-version"], cwd=ASSISTED_SERVICE_CLONE_DIR)
+        cmd(["make", "generate-configuration"], cwd=ASSISTED_SERVICE_CLONE_DIR)
     except subprocess.CalledProcessError as e:
         if e.returncode == 2:
             # We run the command just for its side-effects, we don't care if it fails


### PR DESCRIPTION
Adjusting make target to a new name: `generate-ocp-version` in assisted-service Makefile became `generate-configuration`.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>