### PR TITLE
Correct assisted-service repo in release_tickets.py

### DIFF
--- a/tools/release_tickets.py
+++ b/tools/release_tickets.py
@@ -276,7 +276,7 @@ def get_login(user_password, server):
     return username, password
 
 if __name__ == "__main__":
-    VALID_REPOS = ['assisted-installer', 'assisted=service', 'assisted-installer-agent', 'assisted-ui']
+    VALID_REPOS = ['assisted-installer', 'assisted-service', 'assisted-installer-agent', 'assisted-ui']
     parser = argparse.ArgumentParser()
     loginGroup = parser.add_argument_group(title="login options")
     loginArgs = loginGroup.add_mutually_exclusive_group()


### PR DESCRIPTION
In order to use the release_tickets.py script against the `assisted-service` repo it needs to be changed from `assisted=service` to `assisted-service` in the script.