### PR TITLE
CNI signature - handle empty hosts stanza

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -539,8 +539,13 @@ class CNIConfigurationError(Signature):
 
         host_ip_addresses = self._get_all_host_ip_addresses(cluster)
 
+        if len(host_ip_addresses) == 0:
+            # Fallback because some clusters just have a weird metadata.json without even a `hosts` stanza...
+            host_ip_addresses = [('Unknown', '*')]
+
         hosts = []
         threshold = 1000
+
         for host_id, host_ip in host_ip_addresses:
             try:
                 kubelet_journal = get_journal(triage_logs_tar, host_ip, "kubelet.log")


### PR DESCRIPTION
Fallback because some clusters just have a weird metadata.json without even a `hosts` stanza... So just use a `*` host and the nestedarchive library will find and use the first host folder
