### PR TITLE
move CI tickets to AITRIAGE project on Jira

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,4 +13,3 @@ COPY dev-requirements.txt /tmp/dev-requirements.txt
 RUN pip install -r /tmp/dev-requirements.txt
 
 RUN rm /tmp/*requirements.txt
-

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SERVICE := $(or ${SERVICE},quay.io/ocpmetal/assisted-installer-deployment:latest)
 
 
-all: pep8 pylint image
+all: pycodestyle pylint image
 
 image: build
 	skipper build assisted-installer-deployment

--- a/Makefile.skipper
+++ b/Makefile.skipper
@@ -1,11 +1,11 @@
-all: pep8 pylint build
+all: pycodestyle pylint build
 
-.PHONY: pep8 pylint clean build
+.PHONY: pycodestyle pylint clean build
 build:
 	python setup.py sdist
 
-pep8:
-	pep8 --max-line-length=145 release
+pycodestyle:
+	pycodestyle .
 
 pylint:
 	mkdir -p reports

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
-pep8
+pycodestyle
 pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,12 @@
 [metadata]
-name =assisted-installer-release
+name = assisted-installer-release
 author = Eran Cohen
 author-email = eranco@redhat.com
-home-page = https://github.com/eranco74/assisted-installer-deployment
+home-page = https://github.com/openshift-assisted/assisted-installer-deployment
 summary = Release and deploy openshift assisted installer
 license = Apache-2
 
 requires-dist = setuptools
-
 
 [files]
 packages = 
@@ -17,5 +16,5 @@ packages =
 console_scripts = 
     release = release.main:main
 
-[pep8]
+[pycodestyle]
 max-line-length=145


### PR DESCRIPTION
* Moving CI tickets creation to be against AITRIAGE project in oppose to MGMT
* Fixing ``jira_cmd.py`` code to look on triage tickets on AITRIAGE project
* Allow providing username and password via CLI on ``jira_cmd.py`` script