### PR TITLE
do not automatically close media disconnection tickets by signature

### DIFF
--- a/triage_resolving_filters.json
+++ b/triage_resolving_filters.json
@@ -1,5 +1,2 @@
 {
-  "media_disconnection_signature" : {
-    "MGMT-3176": "Virtual media disconnection"
-  }
 }


### PR DESCRIPTION
We have two problems with it:
* It falsely closes tickets if it sees the word "disconnected" appearing in ``dmesg`` log. It might be the case where a network device is disconnecting.
* We now do a preliminary check to see if the media is disconnected, so we shouldn't get those errors in the first place with current code.