### PR TITLE
Revert "do not automatically close media disconnection tickets by signature"

### DIFF
--- a/triage_resolving_filters.json
+++ b/triage_resolving_filters.json
@@ -1,2 +1,5 @@
 {
+  "media_disconnection_signature" : {
+    "MGMT-3176": "Virtual media disconnection"
+  }
 }


### PR DESCRIPTION
Reverts openshift-assisted/assisted-installer-deployment#112

Media disconnection signature has been fixed, so we can return this into action.