### PR TITLE
move from debian to centos image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,19 +1,29 @@
-FROM python:3
+FROM quay.io/centos/centos:stream8
 
-RUN apt-get update && apt-get install -y \
+# Needed for p7zip package:
+RUN dnf install -y epel-release
+
+RUN dnf update -y && dnf install -y \
     jq \
-    p7zip-full
+    gcc \
+    p7zip \
+    make \
+    python38 \
+    python38-pip \
+    python38-devel \
+        && dnf clean all
 
-RUN pip install pip --upgrade
+RUN alternatives --set python /usr/bin/python3.8
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh
 RUN sh get-docker.sh
+
+RUN pip3 install pip --upgrade
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 
 COPY dev-requirements.txt /tmp/dev-requirements.txt
 RUN pip install -r /tmp/dev-requirements.txt
-#RUN pip install strato-skipper
 
 RUN rm /tmp/*requirements.txt

--- a/tools/jira_cmd.py
+++ b/tools/jira_cmd.py
@@ -357,7 +357,7 @@ class JiraTool():
 
         issue_keys_count = Counter(linked_issue_keys)
         if linked_issue_keys:
-            linked_issues = self._jira.search_issues("issue in (%s)" % (",".join(set(linked_issue_keys))),
+            linked_issues = self._jira.search_issues("project != AITRIAGE AND issue in (%s)" % (",".join(set(linked_issue_keys))),
                                                      maxResults=self._maxResults)
         # remove triaging tickets from the list
         filtered_linked_issues = []


### PR DESCRIPTION
As part of openshift/release#19674, this will allow us to use centos image which we all love and to be able to pull images without relying on the rate-limiter of docker hub.