### PR TITLE
remove redirection to skipper and add a lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,10 @@ SERVICE := $(or ${SERVICE},quay.io/ocpmetal/assisted-installer-deployment:latest
 
 all: pycodestyle pylint image
 
+lint: pycodestyle
+
 image: build
 	skipper build assisted-installer-deployment
 
 local-update: image
 	docker build -t assisted-installer-deployment:local -f Dockerfile.assisted-installer-deployment .
-
-.DEFAULT:
-	skipper -v $(MAKE) $@


### PR DESCRIPTION
Remove redirection to ``skipper make`` when using just ``make``, and add a lint target of current workable lints.