### PR TITLE
Copy images with skopeo and add release Makefile targets

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -1,4 +1,0 @@
-FROM python:3
-COPY dist/assisted-installer-release-*.tar.gz ./
-RUN pip install ./assisted-installer-release-*.tar.gz
-ENTRYPOINT ["release"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -9,6 +9,7 @@ RUN dnf update -y && dnf install -y \
     git \
     p7zip \
     make \
+    skopeo \
     python38 \
     python38-pip \
     python38-devel \

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,14 @@
-SERVICE := $(or ${SERVICE},quay.io/ocpmetal/assisted-installer-deployment:latest)
+all: pycodestyle pylint
 
+clean:
+	rm -rf build dist *egg-info ./__pycache__
+	find -name *.pyc -delete
 
-all: pycodestyle pylint image
+##########
+# Verify #
+##########
 
 lint: pycodestyle
-
-image: build
-	skipper build assisted-installer-deployment
-
-local-update: image
-	docker build -t assisted-installer-deployment:local -f Dockerfile.assisted-installer-deployment .
-
-build:
-	python setup.py sdist
 
 pycodestyle:
 	pycodestyle .
@@ -24,6 +20,12 @@ pylint:
 	mkdir -p reports
 	PYLINTHOME=reports/ pylint release
 
-clean:
-	rm -rf build dist *egg-info ./__pycache__
-	find -name *.pyc -delete
+###########
+# Release #
+###########
+
+snapshot:
+	skipper run python3 tools/update_assisted_installer_yaml.py --full
+
+tag_images:
+	skipper run python3 tools/assisted_installer_stable_promotion.py --tag ${TAG} --version-tag

--- a/tools/assisted_installer_stable_promotion.py
+++ b/tools/assisted_installer_stable_promotion.py
@@ -1,10 +1,11 @@
 import argparse
-import subprocess
-import yaml
-import sys
-import os
 import logging
+import os
+import subprocess
 from datetime import datetime
+
+import yaml
+
 logging.basicConfig(format='%(asctime)s %(message)s')
 logging.getLogger().setLevel(logging.INFO)
 
@@ -52,16 +53,11 @@ def tag_manifest_images(tags):
 
 
 def tag_image(image, tags):
-
-    subprocess.check_output("podman pull {}".format(image), shell=True)
-
-    # seting images names & tags
     for t in tags:
         logging.info("Tagging image {image} to {tag}".format(
             image=image, tag=t))
         tagged_image = "{image}:{tag}".format(image=image.rsplit(":")[0], tag=t)
-        subprocess.check_output("podman tag {} {}".format(image, tagged_image), shell=True)
-        subprocess.check_output("podman push {}".format(tagged_image), shell=True)
+        subprocess.check_output("skopeo copy docker://{} docker://{}".format(image, tagged_image), shell=True)
 
 
 def tag_repo(tags):


### PR DESCRIPTION
Instead of pulling an image with podman, tagging and then pushing the
tag, better to use `skopeo` that can copy images between registries
without downloading them.

Additionally, add `make snapshot` and `make tag_images` targets to
simplify release commands.

Delete `Dockerfile.assisted-installer-deployment` file and its makefile
targets for build and push since it wasn't in use for more than a year.

/cc @eranco74 
/cc @osherdp 
/cc @gamli75 
