### PR TITLE
Couple of small fixes to the image tagging script

### DIFF
--- a/release/gittools.py
+++ b/release/gittools.py
@@ -85,4 +85,8 @@ class GitApiUtils():
         '''Get the user credentials from .netrc file'''
         ncfile = netrc.netrc(netrc_path or os.path.expanduser('~/.netrc'))
         credentials = ncfile.authenticators("github.com")
+
+        if credentials is None:
+            raise RuntimeError("No credentials for 'github.com' has been found under ~/.netrc")
+
         return credentials[0], credentials[2]

--- a/tools/assisted_installer_stable_promotion.py
+++ b/tools/assisted_installer_stable_promotion.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import logging
 import os
@@ -42,14 +43,14 @@ def main():
 
 def tag_manifest_images(tags):
     with open(args.deployment, "r") as f:
-        deployment = yaml.load(f)
+        deployment = yaml.safe_load(f)
     for rep, rep_data in deployment.items():
         for image in rep_data["images"]:
             image_full_name = IMAGE_FORMAT.format(image_name=image, tag=rep_data["revision"])
             try:
                 tag_image(image_full_name, tags)
             except Exception as ex:
-                logging("Failed to tag {image}, reason: {exception}".format(image=image, exception=ex))
+                logging.exception("Failed to tag %s, reason: %s", image, ex)
 
 
 def tag_image(image, tags):


### PR DESCRIPTION
1. Have a more indicative message if user is missing a ``github.com`` section in his ``~/.netrc`` file.
2. Use ``safe_load`` to remove PyYaml warnings.
3. Fix error message printing (before it tried to use ``logging`` module as a function).