### PR TITLE
NO-ISSUE - Retry testgrid tickets creation on JIRAError exception

### DIFF
--- a/tools/create_testgrid_tickets.py
+++ b/tools/create_testgrid_tickets.py
@@ -12,7 +12,7 @@ import re
 from urllib.parse import urlparse
 import requests
 import jira
-
+from retry import retry
 
 DEFAULT_WATCHERS = ["mkowalsk"]
 
@@ -142,6 +142,7 @@ def get_failed_tests():
         raise
 
 
+@retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10)
 def main(arg):
     if arg.user_password is None:
         username, password = get_credentials_from_netrc(urlparse(JIRA_SERVER).hostname, arg.netrc)


### PR DESCRIPTION
```
05:28:21  Traceback (most recent call last):
05:28:21    File "./tools/create_testgrid_tickets.py", line 184, in <module>
05:28:21      main(args)
05:28:21    File "./tools/create_testgrid_tickets.py", line 154, in main
05:28:21      jclient = get_jira_client(username, password)
05:28:21    File "./tools/create_testgrid_tickets.py", line 45, in get_jira_client
05:28:21      return jira.JIRA(JIRA_SERVER, basic_auth=(username, password))
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/client.py", line 506, in __init__
05:28:21      si = self.server_info()
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/client.py", line 2551, in server_info
05:28:21      j = self._get_json("serverInfo")
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/client.py", line 3139, in _get_json
05:28:21      r = self._session.get(url, params=params)
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/resilientsession.py", line 172, in get
05:28:21      return self.__verb("GET", url, **kwargs)
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/resilientsession.py", line 168, in __verb
05:28:21      raise_on_error(response, verb=verb, **kwargs)
05:28:21    File "/usr/local/lib/python3.8/site-packages/jira/resilientsession.py", line 53, in raise_on_error
05:28:21      raise JIRAError(
05:28:21  jira.exceptions.JIRAError: JiraError HTTP 503 url: https://issues.redhat.com/rest/api/2/serverInfo
05:28:21  	text: <!doctype html>
05:28:21  <html class="no-js" lang="en">
```

/cc @YuviGold @osherdp 

