### PR TITLE
fix not defining report variable on all cases

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -204,7 +204,9 @@ class Signature(abc.ABC):
     def _update_triaging_ticket(self, key, comment, should_update=False):
         report = "\n"
         report += self._identifing_string + "\n"
-        report += comment
+        if comment is not None:
+            report += comment
+
         jira_comment = self.find_signature_comment(key)
         signature_name = type(self).__name__
         if self.dry_run_file is not None:
@@ -823,6 +825,9 @@ class ApiInvalidCertificateSignature(ErrorSignature):
                 logs_text += "\n additional {} relevant similar error log lines are found".format(
                     len(invalid_api_log_lines) - 5)
                 report = dedent("""{}""".format(ticket_inform + logs_text))
+            else:
+                report = None
+
             self._update_triaging_ticket(issue_key, report, should_update=should_update)
 
 


### PR DESCRIPTION
Fixing the following error that we have when pattern not matching anything:
```
ERROR      error updating ticket <ticket>
Traceback (most recent call last):
  File "./tools/add_triage_signature.py", line 159, in update_ticket
    self._update_ticket(url, issue_key, should_update=should_update)
  File "./tools/add_triage_signature.py", line 826, in _update_ticket
    self._update_triaging_ticket(issue_key, report, should_update=should_update)
UnboundLocalError: local variable 'report' referenced before assignment
```
/cc @mkowalski 