### PR TITLE
Disable adding watchers to AITRIAGE tickets

### DIFF
--- a/tools/create_triage_tickets.py
+++ b/tools/create_triage_tickets.py
@@ -91,7 +91,9 @@ def create_jira_ticket(jclient, existing_tickets, failure_id, cluster_md):
                                          cluster_md))
 
     logger.info("issue created: %s", new_issue)
-    add_watchers(jclient, new_issue)
+    # (mko 27/10/2021) Disabling adding watchers due to the HTTP 400 error raised when creating
+    #                  AITRIAGE tickets from Jenkins using this script.
+    # add_watchers(jclient, new_issue)
     return new_issue
 
 


### PR DESCRIPTION
It's been noticed that starting from 25th October 2021 we are getting
error HTTP 400 when trying to add watchers to the newly created tickets
via AI Jenkins instance.

In order to have tickets properly processed, we are disabling the part
of the code responsible for adding watchers to AITRIAGE tickets.