### PR TITLE
Remove SMART error message for disk inspection

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -632,15 +632,6 @@ class StorageDetailSignature(Signature):
         smartctl = smart["smartctl"]
         exit_code = smartctl["exit_status"]
 
-        if exit_code != 0:
-            output.append("non-zero smartctl exit code: " + ", ".join(flag.name for flag in cls.SmartctlExitCode
-                                                                      if flag in cls.SmartctlExitCode(exit_code)))
-            if cls.SmartctlExitCode(exit_code) == cls.SmartctlExitCode.SOME_ATA_COMMAND_FAILED_OR_SMART_CHECKSUM_ERROR:
-                if "smart_status" not in smart:
-                    output.append(
-                        "{color:green}*this typically happens on virtual disks*{color} that don't actually have S.M.A.R.T. information,"
-                        " but may also happen due to other reasons")
-
         for message in smartctl.get("messages", []):
             severity = message.get("severity", "unknown")
             message_string = message.get("string", "")


### PR DESCRIPTION
As part of the agent discovery we are collecting SMART data about the
disks present on the host. As there is a lot of drives and controllers
that do not return correct data, we are often encountering non-zero exit
code from smartctl command. In most of the cases the message, instead of
providing a real value, confuses engineers investigating failures of the
cluster installation.

This PR removes the part responsible for printing the error message
returned by smartctl. This means that only parseable fields will be
attached to the AITRIAGE ticket, but the raw error from the command will
not be printed.

Contributes-to: [MGMT-7388](https://issues.redhat.com/browse/MGMT-7388)