### PR TITLE
Add back the -f flag for overriding stable tags

### DIFF
--- a/tools/assisted_installer_stable_promotion.py
+++ b/tools/assisted_installer_stable_promotion.py
@@ -63,7 +63,7 @@ def tag_repo(tags):
     for tag in tags:
         logging.info(f"Tagging repo with {tag}")
         subprocess.check_output(f"git tag {tag} -f", shell=True)
-        subprocess.check_output(f"git push origin {tag}", shell=True)
+        subprocess.check_output(f"git push origin {tag} -f", shell=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Seems like #158 removed usage of ``-f`` flag, which was necessary for stable tags promotion.
/cc @nshidlin 