### PR TITLE
Update image verification script to use new image repository

### DIFF
--- a/assisted-installer.yaml
+++ b/assisted-installer.yaml
@@ -1,24 +1,24 @@
 openshift/assisted-installer:
-  revision: c81363a7fada8d23cfbac86ecc0f97835f1fa043
+  revision: 2b5e964a1a39debf53516ebfc6e5c7572d4f9987
   images:
-  - assisted-installer-controller
-  - assisted-installer
+  - quay.io/edge-infrastructure/assisted-installer-controller
+  - quay.io/edge-infrastructure/assisted-installer
 openshift/assisted-service:
-  revision: b9ab5d3c77580ab93c29bb43cb78cc6b02d54e88
+  revision: 364b9d71b11250ae536787ef354c2d7cb516bb7c
   images:
-  - assisted-service
+  - quay.io/edge-infrastructure/assisted-service
 openshift-assisted/assisted-ui:
-  revision: d60808caecfdb4f6c480dd8e5b07213ea4f210dd
+  revision: b5281fe43c01b2f8adee5483b3bb438bf487cb91
   images:
-  - ocp-metal-ui
+  - quay.io/ocpmetal/ocp-metal-ui
 openshift/assisted-installer-agent:
-  revision: 1b51ecd2786c0f56ceb8f2051fe0af4dae1f7173
+  revision: 55d9252ac2bb120f19a7779b8f5a23ef4c1fe048
   images:
-  - assisted-installer-agent
+  - quay.io/edge-infrastructure/assisted-installer-agent
 openshift/assisted-image-service:
-  revision: a6f4e9968f11ac730523a38fe17bac0661a885ed
+  revision: 725ace298b84e71cfa4be6be364f7483692cc1e0
   images:
-  - assisted-image-service
+  - quay.io/edge-infrastructure/assisted-image-service
 
 # Downstream images:
 # - assisted-installer:

--- a/tools/assisted_installer_stable_promotion.py
+++ b/tools/assisted_installer_stable_promotion.py
@@ -43,11 +43,20 @@ def main():
 def tag_manifest_images(tags):
     with open(args.deployment, "r") as f:
         deployment = yaml.safe_load(f)
+
     for rep_data in deployment.values():
         for image in rep_data["images"]:
-            image_full_name = IMAGE_FORMAT.format(image_name=image, tag=rep_data["revision"])
+            revision = rep_data["revision"]
+
+            if image.startswith("quay.io/ocpmetal/"):
+                pull_spec = f"{image}:{revision}"
+            elif image.startswith("quay.io/edge-infrastructure"):
+                pull_spec = f"{image}:latest-{revision}"
+            else:
+                raise ValueError(f"Unknown repository of image {image}")
+
             try:
-                tag_image(image_full_name, tags)
+                tag_image(pull_spec, tags)
             except Exception as ex:
                 logging.exception("Failed to tag %s, reason: %s", image, ex)
 

--- a/tools/check_ai_images.py
+++ b/tools/check_ai_images.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO, format='%(levelname)-10s %(filename)s:%(
 logger = logging.getLogger(__name__)
 logging.getLogger("__main__").setLevel(logging.INFO)
 
-DEFAULT_REGISTRY = "quay.io/ocpmetal"
+DEFAULT_REGISTRY = "quay.io/edge-infrastructure"
 
 
 @retry(exceptions=subprocess.SubprocessError, tries=3, delay=10)
@@ -27,7 +27,12 @@ def validate_deployment_file(path):
     for val in deployment.values():
         hash = val["revision"]
         for image in val["images"]:
-            pull_spec = f"{DEFAULT_REGISTRY}/{image}:{hash}"
+            if image.startswith("quay.io/ocpmetal/"):
+                pull_spec = f"{image}:{hash}"
+            elif image.startswith("quay.io/edge-infrastructure"):
+                pull_spec = f"{image}:latest-{hash}"
+            else:
+                raise ValueError(f"Unknown repository of image {image}")
 
             if not does_image_exist(pull_spec):
                 raise ValueError(f"Image {pull_spec} couldn't be found")

--- a/tools/update_assisted_installer_yaml.py
+++ b/tools/update_assisted_installer_yaml.py
@@ -8,7 +8,7 @@ import update_hash
 parser = argparse.ArgumentParser()
 parser.add_argument("--deployment", help="deployment yaml file to update", type=str,
                     default=os.path.join(os.path.dirname(__file__), "../assisted-installer.yaml"))
-parser.add_argument('--full', help='update all hases to master', action='store_true')
+parser.add_argument('--full', help='update all hashes to master', action='store_true')
 args = parser.parse_args()
 
 
@@ -17,14 +17,16 @@ def main():
 
     with open(args.deployment, "r") as f:
         deployment = yaml.load(f, Loader=yamlordereddictloader.Loader)
+
     for rep in deployment:
         if full_release:
             hash = subprocess.check_output("git ls-remote https://github.com/{}.git HEAD | cut -f 1".format(rep), shell=True)[:-1]
             hash = hash.decode("utf-8")
         else:
-            hase = os.environ.get(rep, None)
-            if not hase:
+            hash = os.environ.get(rep, None)
+            if not hash:
                 continue
+
         update_hash.update_hash(deployment_yaml=args.deployment, repo=rep, hash=hash)
 
 

--- a/tools/update_hash.py
+++ b/tools/update_hash.py
@@ -16,6 +16,7 @@ def update_hash(deployment_yaml, repo, hash):
 
     with open(deployment_yaml, "r") as f:
         deployment = yaml.load(f)
+
     if repo not in deployment:
         sys.exit("repo {} is not located in the deployment file".format(repo))
     if hash == deployment[repo]:


### PR DESCRIPTION
Make docker registry and repository part of specification of images location, and update code to use the new edge-infrastructure quay.io organization. Images in the new organization should follow a different pattern ``latest-<hash>`` so making the code taking that into account.
For now, only ``assisted-service`` and ``assisted-image-service`` have constant image mirroring, so until handling other images we'll just update what we have.