### PR TITLE
Handle empty host connectivity in get_host_neighbor

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -551,6 +551,8 @@ class CNIConfigurationError(ErrorSignature):
         """
         Given a host object, get the IP addresses of neighboring hosts. These are extracted from the given host's "connectivity" stanza.
         """
+        if host["connectivity"] is None:
+            return []
         try:
             return [(remote_host['host_id'], remote_host['l3_connectivity'][0]['remote_ip_address'])
                     for remote_host in


### PR DESCRIPTION
This commit adds a handler for empty host connectivity in the
get_host_neighbors. This is in order to avoid the following
explosion

```
10:32:16      json.loads(host["connectivity"])['remote_hosts']]
10:32:16    File "/usr/lib64/python3.9/json/__init__.py", line 339, in loads
10:32:16      raise TypeError(f'the JSON object must be str, bytes or bytearray, '
10:32:16  TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```