### PR TITLE
couple of fixes to ocp-bump script

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -11,10 +11,11 @@ RUN dnf update -y && dnf install -y \
     python39-devel \
         && dnf clean all
 
-RUN alternatives --set python /usr/bin/python3.9
+# required for generating configuration in assisted-service repo
+RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/butane/latest/butane --output /usr/local/bin/butane \
+    && chmod +x /usr/local/bin/butane
 
-RUN curl -fsSL https://get.docker.com -o get-docker.sh
-RUN sh get-docker.sh
+RUN alternatives --set python /usr/bin/python3.9
 
 RUN pip3 install pip --upgrade
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-Levenshtein==0.12.2
 retry==0.9.2
 bugzilla-data==0.0.5
 matplotlib==3.5.1
+sh==1.14.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ packages =
 console_scripts = 
     release = release.main:main
     triage_status_report = tools.triage_status_report:main
+    bump_ocp_releases = tools.bump_ocp_releases:main
 
 [flake8]
 max-line-length=145


### PR DESCRIPTION
Doing the following changes:
* Making use of ``sh`` library to ease use of external commands like git and docker
* Building ``assisted-service-build`` image for automatic generation of required changes
* Adding an entrypoint for ``bump_ocp_releases`` to make usage nicer
* Cloning into ``tmp``, to get rid of https://github.com/openshift/release/blob/dd41797d0ecaeaed669766e35ea4c0575ccbc1a5/ci-operator/step-registry/baremetalds/assisted/tools/bump-ocp/baremetalds-assisted-tools-bump-ocp-commands.sh#L11