### PR TITLE
Remove usage of yamlordereddictloader as dicts already ordered

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML==6.0
 requests==2.26.0
-yamlordereddictloader==0.4.0
 ruamel.yaml==0.17.16
 PyGithub==1.55
 python-gitlab==2.10.1

--- a/tools/update_assisted_installer_yaml.py
+++ b/tools/update_assisted_installer_yaml.py
@@ -2,7 +2,6 @@ import argparse
 import subprocess
 import yaml
 import os
-import yamlordereddictloader
 import update_hash
 
 parser = argparse.ArgumentParser()
@@ -16,11 +15,11 @@ def main():
     full_release = args.full or os.environ.get("NIGHTLY_RELEASE", "false") == "true"
 
     with open(args.deployment, "r") as f:
-        deployment = yaml.load(f, Loader=yamlordereddictloader.Loader)
+        deployment = yaml.safe_load(f)
 
     for rep in deployment:
         if full_release:
-            hash = subprocess.check_output("git ls-remote https://github.com/{}.git HEAD | cut -f 1".format(rep), shell=True)[:-1]
+            hash = subprocess.check_output(f"git ls-remote https://github.com/{rep}.git HEAD | cut -f 1", shell=True)[:-1]
             hash = hash.decode("utf-8")
         else:
             hash = os.environ.get(rep, None)

--- a/tools/update_hash.py
+++ b/tools/update_hash.py
@@ -26,6 +26,7 @@ def update_hash(deployment_yaml, repo, hash):
     deployment[repo]["revision"] = hash
     with open(deployment_yaml, "w") as f:
         yaml.dump(deployment, f)
+
     print("updated {} repo with {} hash".format(repo, hash))
 
 


### PR DESCRIPTION
As of Python 3.7, all dictionaries are already ordered by time of insertion, so this dependency is not needed anymore.
/cc @eliorerz 