### PR TITLE
bump_ocp_releases: fixed pre-release images update

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -9,6 +9,7 @@ RUN dnf update -y && dnf install -y \
     python39 \
     python39-pip \
     python39-devel \
+    genisoimage \
         && dnf clean all
 
 # required for generating configuration in assisted-service repo

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ retry==0.9.2
 bugzilla-data==0.0.5
 matplotlib==3.5.1
 sh==1.14.2
+semver==2.13.0


### PR DESCRIPTION
   * Removed 4.10 from skip list.
   * Ensured pre-release proper update of OS images.
   * Used semver to sort ocp releases (as jq sort doesn't support semantic versions).