### PR TITLE
bump_ocp_releases: install golang 1.16

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -7,7 +7,7 @@ ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 RUN dnf update -y && dnf install -y \
     jq \
     gcc \
-    golang \
+    golang-1.16* \
     git \
     make \
     skopeo \


### PR DESCRIPTION
Lock to golang 1.16 as assisted-service is still using it: https://github.com/openshift/assisted-service/blob/bc5eaa51357955fb2be9cad573be533777836c6d/Dockerfile.assisted-service-build#L13

This is required to avoid a diff in the bump PR (in deepcopy files): https://github.com/openshift/assisted-service/pull/3223/files