### PR TITLE
get vcs ref from latest image

### DIFF
--- a/tools/skopeo.py
+++ b/tools/skopeo.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+import re
+from retry import retry
+
+
+class Skopeo:
+    @retry(exceptions=subprocess.SubprocessError, tries=3, delay=10)
+    def get_image_tags_by_pattern(self, repository: str, pattern: str) -> list[str]:
+        """Returns prefixed tags ordered by most recent to least recent"""
+        docker_uri = f"docker://{repository}"
+        out = subprocess.check_output(["skopeo", "list-tags", docker_uri])
+        json_output = out.decode("utf-8")
+        response = json.loads(json_output)
+        if "Tags" not in response:
+            return []
+        # tags are returned by skopeo from oldest to newest. Let's reverse the order
+        return [tag for tag in response["Tags"] if re.search(pattern, tag) is not None][::-1]

--- a/tools/update_assisted_installer_yaml.py
+++ b/tools/update_assisted_installer_yaml.py
@@ -1,14 +1,42 @@
 import argparse
-import subprocess
 import yaml
 import os
 import update_hash
+import skopeo
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--deployment", help="deployment yaml file to update", type=str,
                     default=os.path.join(os.path.dirname(__file__), "../assisted-installer.yaml"))
 parser.add_argument('--full', help='update all hashes to master', action='store_true')
 args = parser.parse_args()
+
+
+def find_first_common_element(lists: list[str]) -> str:
+    if len(lists) < 1:
+        raise ValueError("No lists provided. Cannot find common element")
+
+    for el in lists[0]:
+        if all(el in list for list in lists[1:]):
+            return el
+
+    return None
+
+
+def get_ref_by_docker_image(images):
+    tag_pattern = "^latest-[a-f0-9]{40}$"
+    tag_prefix = "latest-"
+    skopeo_client = skopeo.Skopeo()
+    image_tags = [skopeo_client.get_image_tags_by_pattern(image, tag_pattern)
+                  for image in images]
+
+    if len(image_tags) == 0:
+        raise IndexError(f"Could not find any tags matching pattern `{tag_pattern}` for images `{images}`")
+
+    tag = find_first_common_element(image_tags)
+    if tag is None:
+        raise ValueError(f"Couild not find common tag for images {images}")
+
+    return tag.removeprefix(tag_prefix)
 
 
 def main():
@@ -19,13 +47,11 @@ def main():
 
     for rep in deployment:
         if full_release:
-            hash = subprocess.check_output(f"git ls-remote https://github.com/{rep}.git HEAD | cut -f 1", shell=True)[:-1]
-            hash = hash.decode("utf-8")
+            hash = get_ref_by_docker_image(deployment[rep]['images'])
         else:
             hash = os.environ.get(rep, None)
-            if not hash:
-                continue
-
+        if not hash:
+            continue
         update_hash.update_hash(deployment_yaml=args.deployment, repo=rep, hash=hash)
 
 


### PR DESCRIPTION
This change aims to eliminate possibility of race conditions on pushing images to quay.io and calculating the latest vcs ref available.

Instead of fetching the latest ref from HEAD through git and then checking if the image is ready, we will get the latest tag matching `latest-<git hash>`.
Unfortunately we have some issue with image tagging:
* not all docker images mantain `vcs-ref` label. And even if they did, there are other issues that might break the job if we go that direction (see below)
* not all `latest-<git hash>` tags are generated. Sometimes the process glitches and as result the tag is never generated
* latest tag is not always pointing (having the vcs-ref label) at the latest ref available (mirroring to latest fails - although somewhat rarely). This is not a big issue per se, as worst case scenario we will just snapshot a previous version

NOTE: this script is used in other parts of the CI:
https://github.com/openshift/release/blob/master/ci-operator/config/openshift-assisted/assisted-installer-deployment/openshift-assisted-assisted-installer-deployment-master.yaml#L77
https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift-assisted/assisted-installer-deployment/openshift-assisted-assisted-installer-deployment-master-presubmits.yaml#L216

It looks like those steps might also benefit from the same change, however if it's not so please let me know so we can change this PR accordingly.