### PR TITLE
set default value to status.url when not present for prow jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ lint: flake8 pylint
 flake8:
 	flake8 .
 
+unit-test:
+	pytest tools/
+
 autopep8:
 	autopep8 --recursive --in-place .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ bugzilla-data==0.0.5
 matplotlib==3.5.1
 sh==1.14.2
 semver==2.13.0
+pytest==7.1.1

--- a/tools/ci_status_report.py
+++ b/tools/ci_status_report.py
@@ -93,6 +93,7 @@ def filter_jobs(response: requests.Response) -> typing.Iterator[Job]:
             continue
 
         status = document["status"]
+        url = status.get("url", None)
         job = Job(
             type=JobType(spec["type"]),
             name=spec["job"].replace("pull-ci-openshift-", ""),
@@ -100,7 +101,7 @@ def filter_jobs(response: requests.Response) -> typing.Iterator[Job]:
             repository=repository,
             base_ref=base_ref,
             state=JobState(status["state"]),
-            url=status["url"],
+            url=url,
             start_time=status["startTime"],
             completion_time=status.get("completionTime"),
         )

--- a/tools/test_ci_status_report.py
+++ b/tools/test_ci_status_report.py
@@ -1,0 +1,23 @@
+import os
+import json
+from ci_status_report import filter_jobs
+from unittest.mock import Mock
+
+FIXTURE_PROW_JOB_STATUSES_RESPONSE_PATH = "fixtures/prow_job_statuses.json"
+FIXTURE_PROW_JOB_STATUSES_RESPONSE_N_ITEMS = 826
+
+
+class TestCiStatusReport:
+    def test_filter_jobs(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        response = Mock()
+
+        with open(f"{dir_path}/{FIXTURE_PROW_JOB_STATUSES_RESPONSE_PATH}", "r") as fixture_file:
+            json_text = json.load(fixture_file)
+
+            response.json.side_effect = [json_text]
+            jobs = filter_jobs(response)
+            assert(
+                len(list(jobs))
+                ==
+                FIXTURE_PROW_JOB_STATUSES_RESPONSE_N_ITEMS)


### PR DESCRIPTION
[Example failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-assisted-installer-deployment-master-ci-status-report/1507251112380469248)
Not sure how this did not happen before, we can see an example response for the request to "https://prow.ci.openshift.org/prowjobs.js?omit=annotations,labels,decoration_config,pod_spec" in the [tools/fixtures/prow_job_statuses.json](https://github.com/openshift-assisted/assisted-installer-deployment/compare/master...rccrdpccl:default-when-url-not-present?expand=1#diff-38a1e52ae19eff705979bba4b10d5692c1ce7f82a7ff0395e20a69d0e36e06ca) file - on which I've based the change on.