### PR TITLE
NO-ISSUE: Remove update before package install

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV GOROOT=/usr/lib/golang
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
-RUN dnf update -y && dnf install -y \
+RUN dnf install -y \
     jq \
     gcc \
     golang-1.17* \


### PR DESCRIPTION
Remove `dnf update` before installing the package, it is currently making docker build to fail.
It should have no impact has `dnf install` should perform the update anyway.