### PR TITLE
NO-ISSUE: added networkx pkg to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ matplotlib==3.5.1
 sh==1.14.2
 semver==2.13.0
 pytest==7.1.1
+networkx==2.5.1


### PR DESCRIPTION
Added networkx to requirements.txt - needed for trace_go_mod_dependencies.py tool.

Usage example:
skipper run python3 'tools/trace_go_mod_dependencies.py -p github.com/gorilla/websocket@v1.4.0 -d /Users/daniel/git/assisted-installer'