### PR TITLE
get rid of the redundant redirection to the new domain

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -54,7 +54,7 @@ h1. Cluster Info
 *Configured features:* {features}
 
 *links:*
-* [Cluster on prod|https://cloud.redhat.com/openshift/assisted-installer/clusters/{cluster_id}]
+* [Cluster on prod|https://console.redhat.com/openshift/assisted-installer/clusters/{cluster_id}]
 * [Logs|{logs_url}]
 * [Kraken|https://kraken.psi.redhat.com/clusters/{OCP_cluster_id}]
 * [Metrics|https://grafana.app-sre.devshift.net/d/assisted-installer-cluster-overview/cluster-overview?orgId=1&from=now-1h&to=now&var-datasource=app-sre-prod-04-prometheus&var-clusterId={cluster_id}]


### PR DESCRIPTION
``console.redhat.com`` should serve services, ``cloud.redhat.com`` is more for documentation purposes.
There is a redirection anyway (at least for now, probably it will stay that way for a long time), but no reason for this redundant action.

I left this occurrence, because otherwise it will duplicate the issues: https://github.com/openshift-assisted/assisted-installer-deployment/blob/cc598193ae70ad9a51d642d6f446384482f0c89e/tools/create_triage_tickets.py#L25

/cc @omertuc @eliorerz 