### PR TITLE
NO-ISSUE: retrying when fetching comments

### DIFF
--- a/tools/close_by_signature.py
+++ b/tools/close_by_signature.py
@@ -9,6 +9,7 @@ import json
 
 import jira
 from jira.exceptions import JIRAError
+import retry
 
 import consts
 from add_triage_signature import (
@@ -167,6 +168,7 @@ def filter_and_generate_issues(jira_client, filters, issues):
                 break
 
 
+@retry.retry(exceptions=JIRAError, tries=3, delay=2)  # being resilient to 401 statuses
 def get_issue_comments(jira_client, issue):
     if issue is None:
         return None


### PR DESCRIPTION
We sometimes get 401 Unauthorized status code from Jira service when we
try to fetch comments related to an issue. This change will make 3 tries
for this action (which does not have any side-effects as it's a GET
request) with delay between requests of 2 seconds (so that if the SSO
service is temporarily unavailable we'll try again afterwards).