### PR TITLE
stop bumping 4.7 releases

### DIFF
--- a/tools/bump_ocp_releases.py
+++ b/tools/bump_ocp_releases.py
@@ -61,7 +61,7 @@ ASSISTED_SERVICE_MASTER_DEFAULT_RELEASE_IMAGES_JSON_URL = \
 
 OCP_REPLACE_CONTEXT = ['"{version}"', "ocp-release:{version}"]
 
-SKIPPED_MAJOR_RELEASE = ["4.6"]
+SKIPPED_MAJOR_RELEASE = ["4.6", "4.7"]
 MAJOR_MINOR_VERSION_REGEX = re.compile(r"^([1-9]\d*|0)(\.(([1-9]\d*)|0))$")
 
 CPU_ARCHITECTURE_AMD64 = "amd64"


### PR DESCRIPTION
Users either way cannot install new clusters, so no good reason to keep promoting it to newer z-stream releases.

/cc @gamli75 @danielerez 