### PR TITLE
Raise a more graceful error when fields are None

### DIFF
--- a/tools/triage_status_report.py
+++ b/tools/triage_status_report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import sys
 import json
 import argparse
 import dataclasses
@@ -22,27 +23,31 @@ class IssueData:
     url: str
     features: List[str]
 
+    def __post_init__(self):
+        for field, value in self.__dict__.items():
+            if value is None:
+                raise ValueError(f"Field '{field}' cannot be None")
 
-def _get_issues_data(issues):
-    for issue in issues:
-        key = issue.key
-        url = issue.permalink()
-        user = issue.raw["fields"]["customfield_12319044"]
-        email_domain = issue.raw["fields"]["customfield_12319045"]
 
-        features = [label.replace("FEATURE-", "")
-                    for label in issue.raw["fields"]["labels"]
-                    if "FEATURE" in label]
+def _parse_issue_data(issue):
+    key = issue.key
+    url = issue.permalink()
+    user = issue.raw["fields"]["customfield_12319044"]
+    email_domain = issue.raw["fields"]["customfield_12319045"]
 
-        # filtering some non-important "features"
-        features = [feature for feature in features
-                    if feature not in (
-                        "Requested-hostname",
-                        "Requsted-hostname",  # leaving the value with the typo for backwards compatibility
-                        "NetworkType",
-                    )]
+    features = [label.replace("FEATURE-", "")
+                for label in issue.raw["fields"]["labels"]
+                if "FEATURE" in label]
 
-        yield IssueData(key=key, url=url, user=user, email_domain=email_domain, features=features)
+    # filtering some non-important "features"
+    features = [feature for feature in features
+                if feature not in (
+                    "Requested-hostname",
+                    "Requsted-hostname",  # leaving the value with the typo for backwards compatibility
+                    "NetworkType",
+                )]
+
+    return IssueData(key=key, url=url, user=user, email_domain=email_domain, features=features)
 
 
 def _post_message(webhook, text):
@@ -53,16 +58,33 @@ def _post_message(webhook, text):
         response = requests.post(webhook, data=json.dumps({"text": text}), headers={'Content-type': 'application/json'})
         response.raise_for_status()
 
+        print("Message sent successfully!")
+
 
 def triage_status_report(jira_client, filter_id, webhook):
     jira_filter = jira_client.filter(filter_id)
-    issues = jira_client.search_issues(jira_filter.jql)
+    jira_issues = jira_client.search_issues(jira_filter.jql)
 
     filter_url = jira_filter.viewUrl
-    text = f"There are <{filter_url}|{len(issues)} new triage tickets>\n"
+
+    issues = []
+    errors = []
+    for issue in jira_issues:
+        try:
+            issues.append(_parse_issue_data(issue))
+        except ValueError as e:
+            errors.append((issue, e))
+
+    if errors:
+        for issue, e in errors:
+            print(f"Failed parsing {issue}, error: {e}", file=sys.stderr)
+
+        raise RuntimeError(f"Failed parsing all jira issues. Had {len(errors)} errors")
+
+    text = f"There are <{filter_url}|{len(jira_issues)} new triage tickets>\n"
 
     table = ""
-    for issue in sorted(_get_issues_data(issues)):
+    for issue in sorted(issues):
         table += f"<{issue.url}|{issue.key}>   {issue.user:<15} {issue.email_domain:<15} {issue.features}\n"
 
     if table:


### PR DESCRIPTION
Currently, whenever fields in Jira tickets are not being filled-in (e.g.
user / email domain fields), we [get the following error](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-assisted-installer-deployment-master-triage-status-report/1532255951992655872):
```
Traceback (most recent call last):
  File
"/home/assisted-installer-deployment/./tools/triage_status_report.py",
line 89, in <module>
    main()
  File
"/home/assisted-installer-deployment/./tools/triage_status_report.py",
line 85, in main
    triage_status_report(client, args.filter_id, args.webhook)
  File
"/home/assisted-installer-deployment/./tools/triage_status_report.py",
line 65, in triage_status_report
    for issue in sorted(_get_issues_data(issues)):
  File "<string>", line 4, in __lt__
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

Error is very hard to understand, so this change aims to validate fields
before dataclass logic for comparison actions tries to compare None
value with strings.

In addition, I've added a small message to let the user know when a slack message has been sent (currently it prints nothing which seems very odd)

/cc @omertuc 