### PR TITLE
AgentStepFailureSignature: skip scope errors

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -987,7 +987,10 @@ class AgentStepFailureSignature(Signature):
 
     @classmethod
     def _filter_message(cls, msg) -> bool:
-        filtered_strings = ["dhclient was timed out"]
+        filtered_strings = [
+            "dhclient was timed out",
+            ".scope: no such file or directory"
+        ]
         return any(s in msg['stderr'] for s in filtered_strings)
 
     @classmethod


### PR DESCRIPTION
Ignore "<...>.scope: no such file or directory" errors whecn checking agent stderr. These are coming from podman and caused by cgroups, these don't help with issue triage.

Example issue: https://issues.redhat.com/browse/AITRIAGE-3135