### PR TITLE
Escape Jira message formatting specifiers

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -57,7 +57,7 @@ h1. Cluster Info
 
 *links:*
 * [Cluster on prod - must be logged in as read-only admin|https://console.redhat.com/openshift/assisted-installer/clusters/{cluster_id}]
-** {color:#de350b}*If you find logs on prod that are missing from the Installation logs link below, please upload them as Jira attachments ASAP*{color}
+** {{color:#de350b}}*If you find logs on prod that are missing from the Installation logs link below, please upload them as Jira attachments ASAP*{{color}}
 * [Installation logs - requires VPN|{logs_url}]
 * [Kraken - cluster live telemetry|https://kraken.psi.redhat.com/clusters/{OCP_cluster_id}]
 * [Elastic - installation events|https://kibana-assisted.apps.app-sre-prod-04.i5h0.p1.openshiftapps.com/_dashboards/app/discover?security_tenant=global#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-1M,to:now))&_a=(columns:!(message,cluster.id,cluster.email_domain,cluster.platform.type),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bd9dadc0-7bfa-11eb-95b8-d13a1970ae4d,key:cluster.id,negate:!f,params:(query:'{cluster_id}'),type:phrase),query:(match_phrase:(cluster.id:'{cluster_id}')))),index:bd9dadc0-7bfa-11eb-95b8-d13a1970ae4d,interval:auto,query:(language:kuery,query:''),sort:!())]


### PR DESCRIPTION
Otherwise Python tries to treat them like format strings

```
19:24:53  Traceback (most recent call last):
19:24:53    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 160, in <module>
19:24:53      main(args)
19:24:53    File "<decorator-gen-4>", line 2, in main
19:24:53    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
19:24:53      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
19:24:53    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
19:24:53      return f()
19:24:53    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 122, in main
19:24:53      new_issue = create_jira_ticket(jclient, summaries, failure['name'], cluster)
19:24:53    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 84, in create_jira_ticket
19:24:53      description=FailureDescription(jclient).build_description(
19:24:53    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 367, in build_description
19:24:53      return format_description(cluster_data)
19:24:53    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 85, in format_description
19:24:53      return JIRA_DESCRIPTION.format(**failure_data)
19:24:53  KeyError: 'color'
```