### PR TITLE
AgentStepFailureSignature: skip "name already in use"

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -990,7 +990,8 @@ class AgentStepFailureSignature(Signature):
     def _filter_message(cls, msg) -> bool:
         filtered_strings = [
             "dhclient was timed out",
-            ".scope: no such file or directory"
+            ".scope: no such file or directory",
+            "You have to remove that container to be able to reuse that name"
         ]
         return any(s in msg['stderr'] for s in filtered_strings)
 


### PR DESCRIPTION
Skip this error as the agent may try to run multiple log-sender steps - the error is not helpful to triage a cluster failure