### PR TITLE
add_triage_signatures: format SIGNATURES

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -1285,12 +1285,25 @@ class OSInstallationTime(Signature):
 # Common functionality
 ############################
 JIRA_SERVER = "https://issues.redhat.com"
-SIGNATURES = [AllInstallationAttemptsSignature, ApiInvalidCertificateSignature, FailureDetails,
-              FailureDescription, ComponentsVersionSignature, HostsStatusSignature, HostsExtraDetailSignature,
-              StorageDetailSignature, InstallationDiskFIOSignature, LibvirtRebootFlagSignature,
-              MediaDisconnectionSignature, ConsoleTimeoutSignature, AgentStepFailureSignature,
-              CNIConfigurationError, MustGatherAnalysis, OSInstallationTime,
-              CoreOSInstallerErrorSignature]
+SIGNATURES = [
+    AllInstallationAttemptsSignature,
+    ApiInvalidCertificateSignature,
+    FailureDetails,
+    FailureDescription,
+    ComponentsVersionSignature,
+    HostsStatusSignature,
+    HostsExtraDetailSignature,
+    StorageDetailSignature,
+    InstallationDiskFIOSignature,
+    LibvirtRebootFlagSignature,
+    MediaDisconnectionSignature,
+    ConsoleTimeoutSignature,
+    AgentStepFailureSignature,
+    CNIConfigurationError,
+    MustGatherAnalysis,
+    OSInstallationTime,
+    CoreOSInstallerErrorSignature,
+]
 
 
 ############################


### PR DESCRIPTION
Format signature class list to use one class per line to avoid PR rebases when a new class is added