### PR TITLE
Fix create_triage_tickets FailureDescription error

### DIFF
--- a/tools/create_triage_tickets.py
+++ b/tools/create_triage_tickets.py
@@ -87,7 +87,7 @@ def create_jira_ticket(jira_client, existing_tickets, failure_id, cluster_md):
         components=[{"name": "Cloud-Triage"}],
         priority={"name": "Blocker"},
         issuetype={"name": "Bug"},
-        description=FailureDescription(jira_client).build_description(url, cluster_md),
+        description=FailureDescription(jira_client, issue_key="Unknown").build_description(url, cluster_md),
     )
 
     logger.info("issue created: %s", new_issue)


### PR DESCRIPTION
Following a9e8d9bc310bb4805c1954c72a91eb4faf4474d1, this error started
happening:

http://assisted-jenkins.usersys.redhat.com/job/download_logs/37108/

```
14:54:45  Traceback (most recent call last):
14:54:45    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 172, in <module>
14:54:45      main(args)
14:54:45    File "<decorator-gen-4>", line 2, in main
14:54:45    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
14:54:45      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
14:54:45    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
14:54:45      return f()
14:54:45    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 127, in main
14:54:45      new_issue = create_jira_ticket(jira_client, summaries, failure["name"], cluster)
14:54:45    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 90, in create_jira_ticket
14:54:45      description=FailureDescription(jira_client).build_description(url, cluster_md),
14:54:45    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 443, in __init__
14:54:45      super().__init__(*args, **kwargs, comment_identifying_string="")
14:54:45  TypeError: __init__() missing 1 required positional argument: 'issue_key'
```

This commit should fix it