### PR TITLE
Fix create_triage_tickets FailureDescription error (#249)

### DIFF
--- a/tools/create_triage_tickets.py
+++ b/tools/create_triage_tickets.py
@@ -127,7 +127,9 @@ def main(args):
             new_issue = create_jira_ticket(jira_client, summaries, failure["name"], cluster)
             if new_issue is not None:
                 logs_url = "{}/files/{}".format(LOGS_COLLECTOR, failure["name"])
-                process_ticket_with_signatures(jira_client, logs_url, new_issue.key)
+                process_ticket_with_signatures(
+                    jira_client, logs_url, new_issue.key, only_specific_signatures=None, should_reevaluate=False
+                )
                 close_custom_domain_user_ticket(jira_client, new_issue.key)
 
     if not args.filters_json:


### PR DESCRIPTION
Following a9e8d9bc310bb4805c1954c72a91eb4faf4474d1, this error started
happening:

http://assisted-jenkins.usersys.redhat.com/job/download_logs/37110/console

```
15:54:44  INFO       issue created: AITRIAGE-3426
15:54:44  Traceback (most recent call last):
15:54:44    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 172, in <module>
15:54:44      main(args)
15:54:44    File "<decorator-gen-4>", line 2, in main
15:54:44    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
15:54:44      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
15:54:44    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
15:54:44      return f()
15:54:44    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 130, in main
15:54:44      process_ticket_with_signatures(jira_client, logs_url, new_issue.key)
15:54:44  TypeError: process_ticket_with_signatures() missing 2 required positional arguments: 'only_specific_signatures' and 'dry_run_file'
```

This commit should fix it