### PR TITLE
Fix wrong `tools/create_triage_tickets.py` parameter

### DIFF
--- a/tools/create_triage_tickets.py
+++ b/tools/create_triage_tickets.py
@@ -128,7 +128,11 @@ def main(args):
             if new_issue is not None:
                 logs_url = "{}/files/{}".format(LOGS_COLLECTOR, failure["name"])
                 process_ticket_with_signatures(
-                    jira_client, logs_url, new_issue.key, only_specific_signatures=None, should_reevaluate=False
+                    jira_client,
+                    logs_url,
+                    new_issue.key,
+                    only_specific_signatures=None,
+                    dry_run_file=None,
                 )
                 close_custom_domain_user_ticket(jira_client, new_issue.key)
 


### PR DESCRIPTION
The fix in 0eaec1d4103379af72c046cc01ca03939e7436b9 was invalid,
it passed the wrong parameter, which caused:

http://assisted-jenkins.usersys.redhat.com/job/download_logs/37113/console

```
17:24:48  Traceback (most recent call last):
17:24:48    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 174, in <module>
17:24:48      main(args)
17:24:48    File "<decorator-gen-4>", line 2, in main
17:24:48    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
17:24:48      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
17:24:48    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
17:24:48      return f()
17:24:48    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 130, in main
17:24:48      process_ticket_with_signatures(
17:24:48  TypeError: process_ticket_with_signatures() missing 1 required positional argument: 'dry_run_file'
```

This commit should fix it