### PR TITLE
Fix CoreOSInstallerErrorSignature merge issues

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -1157,7 +1157,7 @@ class CoreOSInstallerErrorSignature(ErrorSignature):
         super().__init__(
             *args,
             **kwargs,
-            signature_label="coreos_installer_error",
+            label="coreos_installer_error",
             comment_identifying_string="h1. CoreOS Installer error",
         )
 


### PR DESCRIPTION
The parameter has been renamed, mismatched caused after merge.

Can see it break here:

http://assisted-jenkins.usersys.redhat.com/job/download_logs/37114/console

```
17:54:58  Traceback (most recent call last):
17:54:58    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 178, in <module>
17:54:58      main(args)
17:54:58    File "<decorator-gen-4>", line 2, in main
17:54:58    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
17:54:58      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
17:54:58    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
17:54:58      return f()
17:54:58    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 130, in main
17:54:58      process_ticket_with_signatures(
17:54:58    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 1702, in process_ticket_with_signatures
17:54:58      signature_class(
17:54:58    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 1157, in __init__
17:54:58      super().__init__(
17:54:58    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 367, in __init__
17:54:58      Signature.__init__(self, *args, **kwargs)
17:54:58  TypeError: __init__() got an unexpected keyword argument 'signature_label'
```