### PR TITLE
Fix `SNOMachineCidrSignature` merge error

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -932,7 +932,7 @@ class SNOMachineCidrSignature(Signature):
     def __init__(self, jira_client):
         super().__init__(jira_client, comment_identifying_string="h1. Invalid machine cidr")
 
-    def _update_ticket(self, url, issue_key):
+    def _process_ticket(self, url, issue_key):
         md = get_metadata_json(url)
 
         cluster = md["cluster"]


### PR DESCRIPTION
Following a merge, a method was renamed in a base class but not in a new
child class.

Caused:
http://assisted-jenkins.usersys.redhat.com/job/download_logs/37116/console

```
18:54:40  Traceback (most recent call last):
18:54:40    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 178, in <module>
18:54:40      main(args)
18:54:40    File "<decorator-gen-4>", line 2, in main
18:54:40    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
18:54:40      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
18:54:40    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
18:54:40      return f()
18:54:40    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 130, in main
18:54:40      process_ticket_with_signatures(
18:54:40    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 1702, in process_ticket_with_signatures
18:54:40      signature_class(
18:54:40  TypeError: Can't instantiate abstract class SNOMachineCidrSignature with abstract method _process_ticket
```

This commit fixes that.