### PR TITLE
Remove `.git` from `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
-.git
 venv


### PR DESCRIPTION
I added `.git` to `.dockerignore` to speed up `skipper ...` commands,
but since this repo's CI does periodic processing and commits / pushes to
itself, `.git` must be present inside the build container.

You can see it fail here:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-assisted-installer-deployment-master-snapshot-repos/1542297103764557824

```
Moving to a writable directory
fatal: not a git repository (or any of the parent directories): .git
{"component":"entrypoint","error":"wrapped process failed: exit status 128","file":"k8s.io/test-infra/prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-06-30T00:14:49Z"}
error: failed to execute wrapped command: exit status 128
```

This commit removes `.git` from `.dockerignore`