### PR TITLE
Fix `SNOMachineCidrSignature` wrong parent constructor call

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -929,8 +929,8 @@ class StorageDetailSignature(Signature):
 
 
 class SNOMachineCidrSignature(Signature):
-    def __init__(self, jira_client):
-        super().__init__(jira_client, comment_identifying_string="h1. Invalid machine cidr")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, comment_identifying_string="h1. Invalid machine cidr")
 
     def _process_ticket(self, url, issue_key):
         md = get_metadata_json(url)


### PR DESCRIPTION
Caused this failure:
http://assisted-jenkins.usersys.redhat.com/job/download_logs/37147/console

```
10:24:45  INFO       issue created: AITRIAGE-3433
10:24:55  Traceback (most recent call last):
10:24:55    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 178, in <module>
10:24:55      main(args)
10:24:55    File "<decorator-gen-4>", line 2, in main
10:24:55    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 73, in retry_decorator
10:24:55      return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
10:24:55    File "/usr/local/lib/python3.9/site-packages/retry/api.py", line 33, in __retry_internal
10:24:55      return f()
10:24:55    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/create_triage_tickets.py", line 130, in main
10:24:55      process_ticket_with_signatures(
10:24:55    File "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/tools/add_triage_signature.py", line 1702, in process_ticket_with_signatures
10:24:55      signature_class(
10:24:55  TypeError: __init__() got an unexpected keyword argument 'should_reevaluate'
```

This commit should fix it