### PR TITLE
Trigger OCP jobs when bumping versions

### DIFF
--- a/tools/bump_ocp_releases.py
+++ b/tools/bump_ocp_releases.py
@@ -354,6 +354,7 @@ def get_pr_body(updates_made):
     return (
         get_release_notes(updates_made) +
         textwrap.dedent(f"""
+            /test {" ".join(f"edge-e2e-metal-assisted-{ocp_version.replace('.', '-')}" for ocp_version in updates_made)}
             /cc {" ".join(f"@{user}" for user in PR_MENTION)}
             /hold
         """)


### PR DESCRIPTION
This should trigger all relevant jobs when we're bumping them (so that
we won't need to test everything on every change to ``data/`` dir).

/cc @gamli75 