### PR TITLE
FlappingValidations: bump threshold

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -1528,7 +1528,7 @@ class FlappingValidations(ErrorSignature):
                 count=f"This validation flapped {v} times",
             )
             for k, v in validation_state_changes.items()
-            if v > 2
+            if v > 4
         ]
 
         if excessive_validation_state_changes:


### PR DESCRIPTION
FlappingValidations now counts both "fixed" and "used to succeed" messages as two flaps, so the report limit is bumped