### PR TITLE
Correctly terminate OSInstallationTime(Signature) unknown host green color

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -1386,9 +1386,7 @@ class OSInstallationTime(Signature):
     writing_image_start_event_regex = re.compile(r".*reached installation stage Writing image to disk$")
     writing_image_end_event_regex = re.compile(r".*reached installation stage Writing image to disk: 100%$")
 
-    unknown_message = (
-        "{color:darkgreen}OS installation time duration could not be determined for this host{color:darkgreen}"
-    )
+    unknown_message = "{color:darkgreen}OS installation time duration could not be determined for this host{color}"
     slow_message = "{{color:red}}OS installation to disk was rather slow, it took {} seconds{{color}}"
     fast_message = "{{color:darkgreen}}OS installation to disk was relatively okay, it took {} seconds{{color}}"
 


### PR DESCRIPTION
Fixes corrupt table for unknown hosts

before:

![image](https://user-images.githubusercontent.com/10882062/178317498-38493115-2c80-414d-b76f-ec95941ad600.png)


after:

![image](https://user-images.githubusercontent.com/10882062/178317595-48a8b977-9fc8-4f4c-a353-43f228f94332.png)

