### PR TITLE
Master failed rebooting

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -249,7 +249,7 @@ class Signature(abc.ABC):
         self._identifing_string = comment_identifying_string
         self._old_identifing_string = old_comment_string
         self.dry_run_file = dry_run_file
-        self.should_reevaluate = dry_run_file
+        self.should_reevaluate = should_reevaluate
         self.issue_key = issue_key
 
     def process_ticket(self, url, issue_key):
@@ -283,10 +283,10 @@ class Signature(abc.ABC):
             )
 
     def _add_signature_function_impact(self, issue_key, labels_to_add):
-        self._add_labels_to_field(custom_field_name(CUSTOM_FIELD_FUNCTION_IMPACT))
+        self._add_labels_to_field(issue_key, labels_to_add, custom_field_name(CUSTOM_FIELD_FUNCTION_IMPACT))
 
     def _add_signature_labels(self, issue_key, labels_to_add):
-        self._add_labels_to_field(FIELD_LABELS)
+        self._add_labels_to_field(issue_key, labels_to_add, FIELD_LABELS)
 
     def find_signature_comment(self, key=None, comments=None):
         assert key or comments

--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -279,7 +279,7 @@ class Signature(abc.ABC):
         if len(new_labels) != 0:
             self._update_fields(
                 issue_key,
-                {FIELD_LABELS: field_existing_labels + new_labels},
+                {field_name: field_existing_labels + new_labels},
             )
 
     def _add_signature_function_impact(self, issue_key, labels_to_add):
@@ -724,7 +724,7 @@ class MasterFailedToPullIgnitionSignature(ErrorSignature):
             *args,
             **kwargs,
             comment_identifying_string="h1. Master nodes failed to pull ignition",
-            label="masters_failed_to_pull_ignition",
+            function_impact_label="masters_failed_to_pull_ignition",
         )
 
     def _process_ticket(self, url, issue_key):

--- a/tools/close_by_signature.py
+++ b/tools/close_by_signature.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import tempfile

--- a/triage_resolving_filters.json
+++ b/triage_resolving_filters.json
@@ -1,2 +1,5 @@
 {
+  "master_failed_to_pull_ignition_signature" : {
+    "MGMT-11089": "Master nodes failed to pull ignition"
+  }
 }


### PR DESCRIPTION
Add MasterFailedToPullIgnition signature, this signature finds tickets for clusters where the bootstrap node is `waiting for control plane` and both master nodes status is rebooting.
Fixed the signatures labeling
Updated triage_resolving_filters.json to close tickets with the above signature