### PR TITLE
Fixed StaticNetworking signature that used to fail in case the infraenv static_network_config was None

### DIFF
--- a/tools/add_triage_signature.py
+++ b/tools/add_triage_signature.py
@@ -1924,9 +1924,9 @@ class StaticNetworking(Signature):
 {yaml.dump(yaml.safe_load(entry["network_yaml"]), default_flow_style=False)}
 {{code}}"""
             for infraenv in infraenvs
+            if infraenv.get("static_network_config", "") not in ("", None)
             for entry in json.loads(infraenv["static_network_config"])
             for interface in entry["mac_interface_map"]
-            if infraenv.get("static_network_config", "") not in ("", None)
         ]
 
         if messages:


### PR DESCRIPTION
Prior to this change, the signature failed with this error:
```
INFO       Updating fields of AITRIAGE-3703
ERROR      error updating ticket AITRIAGE-3703
Traceback (most recent call last):
  File "/home/eran/go/src/github.com/openshift/assisted-installer-deployment/./tools/add_triage_signature.py", line 257, in process_ticket
    self._process_ticket(self._logs_url_to_api(url), issue_key)
  File "/home/eran/go/src/github.com/openshift/assisted-installer-deployment/./tools/add_triage_signature.py", line 1925, in _process_ticket
    messages = [
  File "/home/eran/go/src/github.com/openshift/assisted-installer-deployment/./tools/add_triage_signature.py", line 1931, in <listcomp>
    for entry in json.loads(infraenv["static_network_config"])
  File "/usr/lib64/python3.9/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```
Since the list comprehension first iterates over all the loops and check the condition later.