### PR TITLE
Update Assisted UI to v2.9.1

### DIFF
--- a/assisted-installer.yaml
+++ b/assisted-installer.yaml
@@ -8,7 +8,7 @@ openshift/assisted-service:
   images:
   - quay.io/edge-infrastructure/assisted-service
 openshift-assisted/assisted-ui:
-  revision: c97018fc8d897f4acff5db2997633a43c5ec4568
+  revision: 0791a7d98879fbc4deb3b3712afb861a8338680a
   images:
   - quay.io/edge-infrastructure/assisted-installer-ui
 openshift/assisted-installer-agent:


### PR DESCRIPTION
Manually updating the Assisted Installer version of Assisted UI to v2.9.1

Tagged to `latest-0791a7d98879fbc4deb3b3712afb861a8338680a` which is associated with 

https://quay.io/repository/edge-infrastructure/assisted-installer-ui/manifest/sha256:55c499e4f891900334ee0c2228f85a8a7012b72a004a76aab461a2dc4d6340ae