### PR TITLE
MGMT-11987: fix 4.12 versions getting overridden with 4.11 versions

### DIFF
--- a/tools/bump_ocp_releases.py
+++ b/tools/bump_ocp_releases.py
@@ -60,7 +60,7 @@ ASSISTED_SERVICE_MASTER_DEFAULT_RELEASE_IMAGES_JSON_URL = \
 
 OCP_REPLACE_CONTEXT = ['"{version}"', "ocp-release:{version}"]
 
-SKIPPED_MINOR_OCP_RELEASES = ["4.6", "4.7", "4.12"]
+SKIPPED_MINOR_OCP_RELEASES = ["4.6", "4.7"]
 
 SKIPPED_MINOR_RHCOS_RELEASES = ["4.6", "4.7"]
 
@@ -145,17 +145,17 @@ def get_release_note_url(minor_release):
 
 def get_release_data(minor_release, cpu_architecture):
     # We're using 'x86_64' as a default architecture in the service,
-    # changing to 'amd64' as used for quering the OCP release images.
+    # changing to 'amd64' as used for querying the OCP release images.
     if cpu_architecture == CPU_ARCHITECTURE_X86_64:
         cpu_architecture = CPU_ARCHITECTURE_AMD64
+
     release_data = subprocess.check_output(OCP_INFO_CALL.format(version=minor_release, architecture=cpu_architecture), shell=True)
     release_data = json.loads(release_data)
     if not release_data:
         releases = subprocess.check_output(OCP_INFO_FC_CALL.format(version=minor_release, architecture=cpu_architecture), shell=True)
         releases = json.loads(releases)
-        versions = []
-        for release in releases:
-            versions.append(release['version'])
+        versions = [release["version"] for release in releases
+                    if release["version"].startswith(minor_release)]
         latest_version = max(versions, key=natsort.natsort_key, default=None)
         try:
             release_data = [r for r in releases if r['version'] == latest_version][0]


### PR DESCRIPTION
Apparently the candidate-4.12 channel is pre-filled with 4.11 versions so that people are able to upgrade from 4.11 to 4.12rc immediately:
```
$ curl -s
"https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.12"
| jq -r '.nodes[].version'
4.11.0-rc.1
4.11.0-fc.3
4.11.0-rc.3
4.11.0-rc.0
4.11.0
...
```

This means with current logic we might override versions in cases there is no actual target version (4.x) in a ``*-4.x`` channel (but only ``4.x-1``) versions.

This change brings back the automatic handling of 4.12 versions, and fixes the logic to only include versions that match the minor-version that is searched for.