### PR TITLE
MGMT-11617: only release backend components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ verify_snapshot:
 	skipper run python3 tools/check_ai_images.py
 
 tag_images:
-	skipper run python3 tools/assisted_installer_stable_promotion.py --tag ${TAG} --version-tag
+	skipper run -i python3 tools/assisted_installer_stable_promotion.py --tag ${TAG} --version-tag
 
 release:
-	skipper run release -- --tag ${TAG}
+	skipper run -i release -- --tag ${TAG}

--- a/assisted-installer.yaml
+++ b/assisted-installer.yaml
@@ -1,38 +1,31 @@
 openshift/assisted-installer:
   revision: 61e5f341f575a01c3fe6f8851224a389b62df261
+  categories:
+  - backend
   images:
   - quay.io/edge-infrastructure/assisted-installer-controller
   - quay.io/edge-infrastructure/assisted-installer
 openshift/assisted-service:
   revision: d8ec95e0a7a47917c775c672bd12f295210409d0
+  categories:
+  - backend
   images:
   - quay.io/edge-infrastructure/assisted-service
 openshift-assisted/assisted-ui:
+  categories:
+  - frontend
   revision: 7a8d6aabc4fe3b557d753eefba0b3025efc527c3
   images:
   - quay.io/edge-infrastructure/assisted-installer-ui
 openshift/assisted-installer-agent:
   revision: f725890eb2e0e6de2b6800be949b7d1c3f200d56
+  categories:
+  - backend
   images:
   - quay.io/edge-infrastructure/assisted-installer-agent
 openshift/assisted-image-service:
+  categories:
+  - backend
   revision: d3efa603846e3df2781297d46052e0c244e7f875
   images:
   - quay.io/edge-infrastructure/assisted-image-service
-
-# Downstream images:
-# - assisted-installer:
-#     hash: cc8d5bb07c39e58b851f2cb27fc884511d077b95
-#     image name: registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-rhel8:v1.0.0-87
-#     staging image name: registry.stage.redhat.io/openshift4/assisted-installer-rhel8:v1.0.0-87
-#     production image name: registry.redhat.io/rhai-tech-preview/assisted-installer-rhel8:v1.0.0-87
-# - assisted-installer-controller:
-#     hash: cc8d5bb07c39e58b851f2cb27fc884511d077b95
-#     image name: registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-reporter-rhel8:v1.0.0-101
-#     staging image name: registry.stage.redhat.io/openshift4/assisted-installer-reporter-rhel8:v1.0.0-101
-#     production image name: registry.redhat.io/rhai-tech-preview/assisted-installer-reporter-rhel8:v1.0.0-101
-# - assisted-installer-agent:
-#     hash: 60ac74ef05e45fd612222f3bd17f0b148d346d98
-#     image name: registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-agent-rhel8:v1.0.0-62
-#     staging image name: registry.stage.redhat.io/openshift4/assisted-installer-agent-rhel8:v1.0.0-62
-#     production image name: registry.redhat.io/rhai-tech-preview/assisted-installer-agent-rhel8:v1.0.0-62

--- a/release/main.py
+++ b/release/main.py
@@ -26,11 +26,14 @@ def tag_all(manifest, tag, delete_if_exists=False):
     '''Read the manifest file and create a tag for each entry'''
     logger = get_logger()
     with open(manifest, 'r') as manifest_file:
-        manifest_contnet = yaml.safe_load(manifest_file)
-    logger.info("Creating %s tag for all repos", tag)
+        manifest_content = yaml.safe_load(manifest_file)
+    logger.info("Creating %s tag for all backend repos", tag)
     gtools = gittools.GitApiUtils()
     repos_with_tag = []
-    for repo in manifest_contnet.keys():
+    for repo, component_data in manifest_content.items():
+        if "backend" not in component_data["categories"]:
+            continue
+
         if gtools.tag_exists(repo, tag):
             repos_with_tag.append(repo)
     if repos_with_tag:
@@ -40,9 +43,13 @@ def tag_all(manifest, tag, delete_if_exists=False):
         else:
             raise ValueError(f"{tag} tag already exists in these repositories {repos_with_tag}")
 
-    for repo, repo_info in manifest_contnet.items():
-        logger.info("Creating %s tag in repo: %s, revision: %s", tag, repo, repo_info['revision'])
-        gtools.create_tag(repo, repo_info['revision'], tag)
+    for repo, component_data in manifest_content.items():
+        if "backend" not in component_data["categories"]:
+            continue
+
+        logger.info("Creating %s tag in repo: %s, revision: %s", tag, repo, component_data['revision'])
+        gtools.create_tag(repo, component_data['revision'], tag)
+
     logger.info("Done")
 
 

--- a/tools/assisted_installer_stable_promotion.py
+++ b/tools/assisted_installer_stable_promotion.py
@@ -44,16 +44,14 @@ def tag_manifest_images(tags):
     with open(args.deployment, "r") as f:
         deployment = yaml.safe_load(f)
 
-    for rep_data in deployment.values():
-        for image in rep_data["images"]:
-            revision = rep_data["revision"]
+    for component in deployment.values():
+        if "backend" not in component["categories"]:
+            continue
 
-            if image.startswith("quay.io/ocpmetal/"):
-                pull_spec = f"{image}:{revision}"
-            elif image.startswith("quay.io/edge-infrastructure"):
-                pull_spec = f"{image}:latest-{revision}"
-            else:
-                raise ValueError(f"Unknown repository of image {image}")
+        for image in component["images"]:
+            revision = component["revision"]
+
+            pull_spec = f"{image}:latest-{revision}"
 
             try:
                 tag_image(pull_spec, tags)


### PR DESCRIPTION
When running make tag_images release on the release process, we also tag images of UI that should be updated separately in another process.

This change fixes this issue by categorizing the different components, and only issuing the releasing for backend components.