### PR TITLE
NO-ISSUE: Normalize JIRA title when checking for duplicate AITRIAGE

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig
+
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/tools/consts.py
+++ b/tools/consts.py
@@ -1,1 +1,2 @@
 JIRA_SERVER = "https://issues.redhat.com"
+TITLE_NORMALIZATION_REGEX = r'[\W_]+'

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,4 +1,6 @@
 import netrc
+import re
+from consts import TITLE_NORMALIZATION_REGEX
 
 
 def get_credentials_from_netrc(*, hostname, netrc_file=None):
@@ -8,3 +10,15 @@ def get_credentials_from_netrc(*, hostname, netrc_file=None):
         return None, None
 
     return credentials[0], credentials[2]
+
+
+def normalize_jira_title(s):
+    # We use non-compiled regex as based on the benchmark from StackOverflow
+    # (https://stackoverflow.com/a/1277047/1864702) it is one of the fastest methods
+    # that also allows for an easy syntax and reuse of the function.
+    return re.sub(TITLE_NORMALIZATION_REGEX, '', s)
+
+
+def normalize_jira_titles(titles):
+    map_object = map(normalize_jira_title, list(titles))
+    return list(map_object)


### PR DESCRIPTION
We are stripping all non alphanumeric characters in order to avoid issues when changing format of the JIRA title.

/cc @adriengentil 