### PR TITLE
Use quay image for Assisted UI lib v2.12.0

### DIFF
--- a/assisted-installer.yaml
+++ b/assisted-installer.yaml
@@ -14,7 +14,7 @@ openshift/assisted-service:
 openshift-assisted/assisted-ui:
   categories:
   - frontend
-  revision: 9cbcfc97d86b2ca04a9fdeb7da183126086f6ea7
+  revision: 71faac66e91f4049f00f4e4513a921a45e217fd3
   images:
   - quay.io/edge-infrastructure/assisted-installer-ui
 openshift/assisted-installer-agent:


### PR DESCRIPTION
Linked to Assisted UI lib version 2.12.0

https://quay.io/repository/edge-infrastructure/assisted-installer-ui/manifest/sha256:27c2310c3141d271017e8ad6a9fb753d2e0889fcce8707ed3f3a903eaf345135