### PR TITLE
MGMT-13191: fix image tagging of hotfix releases

### DIFF
--- a/tools/skopeo_utils.py
+++ b/tools/skopeo_utils.py
@@ -16,3 +16,11 @@ class Skopeo:
             return []
         # tags are returned by skopeo from oldest to newest. Let's reverse the order
         return [tag for tag in response["Tags"] if re.search(pattern, tag) is not None][::-1]
+
+    def tag_image(self, image: str, source_tag: str, target_tag: str) -> None:
+        subprocess.check_output([
+            "skopeo",
+            "copy",
+            f"docker://{image}:{source_tag}",
+            f"docker://{image}:{target_tag}",
+        ])

--- a/tools/update_assisted_installer_yaml.py
+++ b/tools/update_assisted_installer_yaml.py
@@ -1,9 +1,10 @@
 import argparse
 import yaml
 import os
-import update_hash
-import skopeo
 import github
+
+import update_hash
+import skopeo_utils
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--deployment", help="deployment yaml file to update", type=str,
@@ -26,7 +27,7 @@ def find_first_common_element(lists: list[str]) -> str:
 def get_ref_by_docker_image(images):
     tag_pattern = "^latest-[a-f0-9]{40}$"
     tag_prefix = "latest-"
-    skopeo_client = skopeo.Skopeo()
+    skopeo_client = skopeo_utils.Skopeo()
     image_tags = [skopeo_client.get_image_tags_by_pattern(image, tag_pattern)
                   for image in images]
 
@@ -35,7 +36,7 @@ def get_ref_by_docker_image(images):
 
     tag = find_first_common_element(image_tags)
     if tag is None:
-        raise ValueError(f"Couild not find common tag for images {images}")
+        raise ValueError(f"Could not find common tag for images {images}")
 
     return tag.removeprefix(tag_prefix)
 


### PR DESCRIPTION
After the change in https://github.com/openshift/release/pull/35166, we need to change our hotfix releases tagging to also consider docker images with the prefix of ``hotfix-``.

This change checks for both, to cope with both y-versions (x.y.0) and for hotfixes (x.y.z!=0).

In addition, it changes ``skopeo->skopeo_utils`` (it took me literally 10 minutes to understand ``skopeo`` module is not a third-party), and it removes the infamous ``except Exception as ex: <log>`` from image tagging.

/hold