### PR TITLE
Remove duplicated mount of netrc

### DIFF
--- a/skipper.yaml
+++ b/skipper.yaml
@@ -5,5 +5,4 @@ make:
   makefile: Makefile
 volumes:
   - $PWD/assisted-installer.yaml:/assisted-installer.yaml:rw
-  - $HOME/.netrc:/root/.netrc:ro
   - $HOME/.ssh/known_hosts:/root/.ssh/known_hosts:ro


### PR DESCRIPTION
Apparently skipper already mounts ``~/.netrc`` in its own source code: https://github.com/Stratoscale/skipper/blob/c04428a50b221b806e096ffd14361f31b2f0282b/skipper/runner.py#L131

With older podman versions it makes an error because it cannot stand the fact that we're mentioning twice the same volumes.

This removes the duplication from assisted-installer-deployment side.