### PR TITLE
Add slow image download signature

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,3 +27,4 @@ aliases:
     - osherdp
     - omertuc
     - eliorerz
+    - eranco74


### PR DESCRIPTION
See example [here](https://issues.redhat.com/browse/AITRIAGE-4999?jql=project%20in%20(12325045%2C%2012327120)%20AND%20text%20~%20%22Assisted%20Controller%20is%20not%20running%20on%20the%20cluster%22%20AND%20cf%5B12317358%5D%20!%3D%20%20SIGNATURE_missing_pivot_ostree%20ORDER%20BY%20created%20DESC%2C%20resolution%20ASC%2C%20updated%20DESC%2C%20component%20ASC)