### PR TITLE
NO-ISSUE: Try to make triage report relient to errors

### DIFF
--- a/tools/triage_status_report.py
+++ b/tools/triage_status_report.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
-import os
-import sys
-import json
 import argparse
 import dataclasses
+import json
+import os
+import sys
 from typing import List
 
+import consts
 import jira
 import requests
 
-import consts
-
-
 FILTER_ID = 12380672
+MISSING_VALUE = "<MISSING>"
 
 
 @dataclasses.dataclass(order=True)
@@ -26,7 +25,10 @@ class IssueData:
     def __post_init__(self):
         for field, value in self.__dict__.items():
             if value is None:
-                raise ValueError(f"Field '{field}' cannot be None")
+                if field == "features":
+                    self.features = [MISSING_VALUE]
+                else:
+                    setattr(self, field, MISSING_VALUE)
 
 
 def _parse_issue_data(issue):


### PR DESCRIPTION
Default missing values from Jira ticket to a default value. That way,
the report is still sent to the channel even if tickets are malformed.

x-ref: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-assisted-installer-deployment-master-triage-status-report/1618141654198259712
