### PR TITLE
MGMT-13401: store cluster logs as Jira attachments

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -34,6 +34,9 @@ pipeline {
                     sh "scripts/install_environment.sh install_skipper"
                     sh "make image_build"
                 }
+
+                sh "rm -rf assisted-installer-deployment"
+                sh "git clone ${ASSISTED_INSTALLER_DEPLOYMENT_REMOTE} --branch ${ASSISTED_INSTALLER_DEPLOYMENT_BRANCH}"
             }
         }
 
@@ -42,14 +45,15 @@ pipeline {
                 dir ('assisted-test-infra') {
                     sh "make download_cluster_logs"
                 }
+
+                dir ('assisted-installer-deployment') {
+                    sh "skipper run ./tools/triage/attach_logs_in_jira.py --source-dir ${LOGS_DEST} --jira-access-token ${JIRA_ACCESS_TOKEN} --verbose"
+                }
             }
         }
 
         stage('Create tickets') {
             steps {
-                sh "rm -rf assisted-installer-deployment"
-                sh "git clone ${ASSISTED_INSTALLER_DEPLOYMENT_REMOTE} --branch ${ASSISTED_INSTALLER_DEPLOYMENT_BRANCH}"
-
                 dir ('assisted-installer-deployment') {
                     sh "skipper run ./tools/triage/create_triage_tickets.py --jira-access-token ${JIRA_ACCESS_TOKEN} -v"
                 }

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ retry==0.9.2
 pytest==7.1.1
 networkx==2.5.1
 insights-core>3.0.276
+pyfakefs==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 async-timeout==4.0.2
     # via redis
-attrs==21.4.0
+attrs==22.2.0
     # via pytest
-cachecontrol==0.12.11
+cachecontrol[filecache]==0.12.11
     # via insights-core
-certifi==2022.6.15
+certifi==2022.12.7
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 colorlog==4.7.2
     # via -r requirements.in
-cryptography==37.0.2
+cryptography==39.0.0
     # via secretstorage
 decorator==4.4.2
     # via
@@ -31,17 +31,19 @@ defusedxml==0.7.1
     #   insights-core
     #   jira
 deprecated==1.2.13
-    # via
-    #   pygithub
-    #   redis
+    # via pygithub
 fuzzywuzzy==0.18.0
     # via -r requirements.in
-idna==3.3
+idna==3.4
     # via requests
-iniconfig==1.1.1
+importlib-metadata==6.0.0
+    # via keyring
+iniconfig==2.0.0
     # via pytest
-insights-core==3.0.280
+insights-core==3.1.4
     # via -r requirements.in
+jaraco-classes==3.2.3
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
@@ -50,12 +52,16 @@ jinja2==3.1.2
     # via insights-core
 jira==3.1.1
     # via -r requirements.in
-keyring==23.6.0
+keyring==23.13.1
     # via jira
 lockfile==0.12.2
-    # via insights-core
-markupsafe==2.1.1
+    # via
+    #   cachecontrol
+    #   insights-core
+markupsafe==2.1.2
     # via jinja2
+more-itertools==9.0.0
+    # via jaraco-classes
 msgpack==1.0.4
     # via cachecontrol
 multi-key-dict==2.0.3
@@ -64,14 +70,13 @@ nestedarchive==0.2.4
     # via -r requirements.in
 networkx==2.5.1
     # via -r requirements.in
-oauthlib==3.2.1
+oauthlib==3.2.2
     # via requests-oauthlib
 packaging==21.0
     # via
     #   -r requirements.in
     #   pytest
-    #   redis
-pbr==5.9.0
+pbr==5.11.1
     # via python-jenkins
 pluggy==1.0.0
     # via pytest
@@ -81,9 +86,11 @@ py==1.11.0
     #   retry
 pycparser==2.21
     # via cffi
+pyfakefs==5.1.0
+    # via -r requirements.in
 pygithub==1.55
     # via -r requirements.in
-pyjwt==2.4.0
+pyjwt==2.6.0
     # via pygithub
 pynacl==1.5.0
     # via pygithub
@@ -103,7 +110,7 @@ pyyaml==6.0
     # via
     #   -r requirements.in
     #   insights-core
-redis==4.3.4
+redis==4.4.2
     # via insights-core
 requests==2.26.0
     # via
@@ -119,7 +126,7 @@ requests==2.26.0
     #   requests-toolbelt
 requests-oauthlib==1.3.1
     # via jira
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via
     #   jira
     #   python-gitlab
@@ -127,7 +134,7 @@ retry==0.9.2
     # via -r requirements.in
 ruamel-yaml==0.17.16
     # via -r requirements.in
-secretstorage==3.3.2
+secretstorage==3.3.3
     # via keyring
 six==1.16.0
     # via
@@ -140,10 +147,12 @@ tomli==2.0.1
     # via pytest
 tqdm==4.59.0
     # via -r requirements.in
-urllib3==1.26.9
+urllib3==1.26.14
     # via requests
 wrapt==1.14.1
     # via deprecated
+zipp==3.12.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -7,5 +7,6 @@ volumes:
   - $PWD/assisted-installer.yaml:/assisted-installer.yaml:rw
   - $HOME/.ssh/known_hosts:/root/.ssh/known_hosts:ro
   - ${XDG_RUNTIME_DIR}/containers/auth.json:/run/user/0/containers/auth.json:ro
+  - /var/ai-logs:/var/ai-logs # using this when downloading triage logs
 env:
   REGISTRY_AUTH_FILE: /run/user/0/containers/auth.json

--- a/tests/tools/triage/test_attach_logs_in_jira.py
+++ b/tests/tools/triage/test_attach_logs_in_jira.py
@@ -1,0 +1,203 @@
+import re
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+import jira
+import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+from tools.triage.attach_logs_in_jira import attach_logs_in_jira
+
+
+@pytest.fixture(autouse=True)
+def jira_client():
+    with patch("tools.triage.attach_logs_in_jira.JiraClientFactory") as jira_mock:
+        yield jira_mock.create()
+
+
+@pytest.fixture(autouse=True)
+def get_or_create_triage_ticket():
+    with patch("tools.triage.attach_logs_in_jira.get_or_create_triage_ticket") as tickets_creation_mock:
+        yield tickets_creation_mock
+
+
+def test_storing_artifacts(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_file(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "log.log")
+    fs.create_file(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "events.json")
+
+    issue = Mock(spec=jira.Issue, fields=Mock(attachment=[]))
+    get_or_create_triage_ticket.return_value = issue
+
+    attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/log.log"
+    )
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/events.json"
+    )
+
+
+def test_archiving_directories(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files")
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files" / "events.json"
+    )
+
+    issue = Mock(spec=jira.Issue, fields=Mock(attachment=[]))
+    get_or_create_triage_ticket.return_value = issue
+
+    attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    jira_client.add_attachment.assert_any_call(
+        issue=issue,
+        attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/cluster_files.tar.gz",
+    )
+
+
+def test_archiving_directories_with_suffix(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files.d")
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files.d" / "events.json"
+    )
+
+    issue = Mock(spec=jira.Issue, fields=Mock(attachment=[]))
+    get_or_create_triage_ticket.return_value = issue
+
+    attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    jira_client.add_attachment.assert_any_call(
+        issue=issue,
+        attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/cluster_files.d.tar.gz",
+    )
+
+
+def test_skip_archiving_directory_if_already_did(
+    fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket
+):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files")
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files" / "events.json"
+    )
+    fs.create_file(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "cluster_files.tar.gz")
+
+    issue = Mock(spec=jira.Issue, fields=Mock(attachment=[]))
+    get_or_create_triage_ticket.return_value = issue
+
+    with patch("tools.triage.attach_logs_in_jira.tarfile.open") as tarfile_mock:
+        attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+        tarfile_mock.assert_not_called()
+
+    jira_client.add_attachment.assert_any_call(
+        issue=issue,
+        attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/cluster_files.tar.gz",
+    )
+
+
+def test_splitting_big_artifacts(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "short-enough.log",
+        contents="a" * 49 * 2**20,
+    )
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "big.log", contents="a" * 51 * 2**20
+    )
+
+    issue = Mock(spec=jira.Issue, fields=Mock(attachment=[]))
+    get_or_create_triage_ticket.return_value = issue
+
+    attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/short-enough.log"
+    )
+
+    # making sure original big file didn't get attached, but its parts are
+    assert (
+        call(issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/big.log")
+        not in jira_client.add_attachment.call_args_list
+    )
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/big.log-part-0"
+    )
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/big.log-part-1"
+    )
+
+
+def test_skipping_already_attached_files(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "existing-file.log", st_size=1111
+    )
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "new-file.log", st_size=2222
+    )
+    fs.create_file(
+        source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "changed-file.log", st_size=3333
+    )
+
+    issue = Mock(
+        spec=jira.Issue,
+        fields=Mock(
+            attachment=[Mock(filename="existing-file.log", size=1111), Mock(filename="changed-file.log", size=1122)]
+        ),
+    )
+    get_or_create_triage_ticket.return_value = issue
+
+    attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    assert (
+        call(
+            issue=issue,
+            attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/existing-file.log",
+        )
+        not in jira_client.add_attachment.call_args_list
+    )
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/new-file.log"
+    )
+    jira_client.add_attachment.assert_any_call(
+        issue=issue, attachment="/var/ai-logs/2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658/changed-file.log"
+    )
+
+
+def test_retrying_jira_errors(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_file(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "log.log")
+
+    get_or_create_triage_ticket.side_effect = jira.JIRAError("jira error")
+
+    with pytest.raises(ExceptionGroup, match=re.escape("Failed attaching logs for all issues (1 sub-exception)")):
+        attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    assert get_or_create_triage_ticket.call_count == 3
+
+
+def test_aggregating_errors(fs: FakeFilesystem, jira_client: jira.JIRA, get_or_create_triage_ticket):
+    source_dir = Path("/var/ai-logs")
+    fs.create_dir(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658")
+    fs.create_file(source_dir / "2021-12-29_05:04:07_ff5b2fa7-3d6d-4493-aeee-253c4f29e658" / "log.log")
+
+    fs.create_dir(source_dir / "2022-06-10_18:24:23_b677eb1e-784a-45e1-bee9-e7958b9bcfb2")
+    fs.create_file(source_dir / "2022-06-10_18:24:23_b677eb1e-784a-45e1-bee9-e7958b9bcfb2" / "log.log")
+
+    get_or_create_triage_ticket.side_effect = jira.JIRAError("jira error")
+
+    with pytest.raises(ExceptionGroup, match=re.escape("Failed attaching logs for all issues (2 sub-exceptions)")):
+        attach_logs_in_jira(source_dir=source_dir, jira_access_token="")
+
+    assert get_or_create_triage_ticket.call_count == 6

--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -30,7 +30,7 @@ from retry import retry
 from tabulate import tabulate
 
 from tools.jira_client import JiraClientFactory
-from tools.triage.common import get_cluster_logs_base_url
+from tools.triage.common import JIRA_PROJECT, get_cluster_logs_base_url
 
 DEFAULT_DAYS_TO_HANDLE = 30
 SUMMARY_PATTERN = r"cloud\.redhat\.com failure: (?P<failure_id>.+)"
@@ -98,14 +98,6 @@ def config_logger(verbose):
 
 def format_description(failure_data):
     return JIRA_DESCRIPTION.format(**failure_data)
-
-
-def days_ago(datestr):
-    try:
-        return (datetime.now() - dateutil.parser.isoparse(datestr)).days
-    except Exception:
-        logger.debug("Cannot parse date: %s", datestr)
-        return 9999
 
 
 class FailedToGetMetadataException(Exception):
@@ -1158,7 +1150,7 @@ class AllInstallationAttemptsSignature(Signature):
         cluster = md["cluster"]
         cluster_id = cluster["id"]
         cluster_triage_tickets = self._jira_client.search_issues(
-            f"""project = AITRIAGE AND "Cluster ID" ~ {cluster_id}"""
+            f"""project = {JIRA_PROJECT} AND "Cluster ID" ~ {cluster_id}"""
         )
         for ticket in cluster_triage_tickets:
             if issue_key == ticket.key:
@@ -2744,7 +2736,7 @@ def get_logs_url_from_issue(issue):
 
 def get_all_triage_tickets(jira_client, only_recent=False):
     recent_filter = "" if not only_recent else "and created >= -31d"
-    query = f"project = AITRIAGE AND component = Cloud-Triage {recent_filter}"
+    query = f"project = {JIRA_PROJECT} AND component = Cloud-Triage {recent_filter}"
 
     return jira_client.search_issues(query, maxResults=None)
 

--- a/tools/triage/attach_logs_in_jira.py
+++ b/tools/triage/attach_logs_in_jira.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import os
+import sys
+import tarfile
+from functools import partial
+from pathlib import Path
+from typing import Optional
+
+import jira
+import retry
+
+from tools.jira_client import JiraClientFactory
+from tools.triage.common import get_or_create_triage_ticket
+from tools.utils import days_ago
+
+DEFAULT_DAYS_TO_ATTACH_LOGS = 3
+JIRA_ATTACHMENT_MAX_SIZE = 50 * 2**20  # 50MiB
+
+log = logging.getLogger(__name__)
+stream_handler = logging.StreamHandler(sys.stderr)
+stream_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+log.addHandler(stream_handler)
+
+
+def _archive_dir(directory: Path) -> Path:
+    archived_file = Path(f"{directory}.tar.gz")
+    log.info("Archiving directory %s to %s", directory, archived_file)
+    with tarfile.open(archived_file, "w:gz") as tar:
+        tar.add(directory, directory.name)
+
+    return archived_file
+
+
+def _split_file(path: Path, chunk_size: int) -> None:
+    log.info("Splitting %s to several files", path)
+    with path.open("rb") as whole_file:
+        read_chunk = partial(whole_file.read, chunk_size)
+        for i, chunk in enumerate(iter(read_chunk, b"")):
+            with open(f"{path}-part-{i}", "wb") as part_file:
+                part_file.write(chunk)
+
+
+@retry.retry(exceptions=jira.JIRAError, tries=3, logger=log)
+def _attach_logs_for_cluster(jira_client: jira.JIRA, cluster_logs_dir: Path):
+    issue = get_or_create_triage_ticket(jira_client=jira_client, failure_id=cluster_logs_dir.name)
+
+    for artifact in cluster_logs_dir.iterdir():
+        if artifact.is_dir():
+            if Path(f"{artifact}.tar.gz").exists():
+                log.debug("Skip archiving %s as it's already archived", artifact)
+            else:
+                artifact = _archive_dir(artifact)
+
+        if artifact.stat().st_size > JIRA_ATTACHMENT_MAX_SIZE:
+            _split_file(artifact, chunk_size=JIRA_ATTACHMENT_MAX_SIZE)
+
+    for artifact in cluster_logs_dir.iterdir():
+        if artifact.is_dir() or artifact.stat().st_size > JIRA_ATTACHMENT_MAX_SIZE:
+            log.debug("Skip %s as it had been replaced with other files", artifact)
+            continue
+
+        matching_attachments = [
+            attachment for attachment in issue.fields.attachment if artifact.name == attachment.filename
+        ]
+        if len(matching_attachments) > 0 and matching_attachments[0].size == artifact.stat().st_size:
+            log.debug("File %s already exists at %s. Skipping upload", artifact, issue)
+            continue
+
+        log.info("Attaching %s to issue %s", artifact, issue)
+        jira_client.add_attachment(issue=issue, attachment=str(artifact))
+
+
+def attach_logs_in_jira(source_dir: Path, jira_access_token: str, max_days: Optional[int] = None):
+    jira_client = JiraClientFactory.create(jira_access_token=jira_access_token)
+
+    errors = []
+
+    for cluster_logs_dir in source_dir.iterdir():
+        date = cluster_logs_dir.name.split("_")[0]
+        if max_days is not None and days_ago(date) > max_days:
+            log.debug(
+                "Ignoring old cluster dir %s as it was created more than %d days ago", cluster_logs_dir.name, max_days
+            )
+            continue
+
+        try:
+            _attach_logs_for_cluster(jira_client, cluster_logs_dir)
+        except (jira.JIRAError, RuntimeError) as err:
+            errors.append(err)
+
+    if errors:
+        for error in errors:
+            log.error("Error while attaching logs in Jira", exc_info=error)
+
+        raise ExceptionGroup("Failed attaching logs for all issues", errors)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a Jira ticket for each installation attempt, and upload artifacts as Jira attachments."
+    )
+
+    parser.add_argument("--source-dir", help="Local directory with logs for all clusters")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Output verbose logging")
+    parser.add_argument(
+        "--max-days",
+        default=DEFAULT_DAYS_TO_ATTACH_LOGS,
+        type=int,
+        help="Create tickets only for failures that happened the last amount of days. Earlier failures will be ignored",
+    )
+    parser.add_argument(
+        "--jira-access-token",
+        default=os.environ.get("JIRA_ACCESS_TOKEN"),
+        required=False,
+        help="Personal access token for accessing Jira",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
+
+    attach_logs_in_jira(
+        source_dir=Path(args.source_dir),
+        jira_access_token=args.jira_access_token,
+        max_days=args.max_days,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -17,7 +17,6 @@ from tools.triage.add_triage_signature import (
     CUSTOM_FIELD_DOMAIN,
     CUSTOM_FIELD_IGNORED_DOMAINS,
     custom_field_name,
-    days_ago,
     process_ticket_with_signatures,
 )
 from tools.triage.common import (
@@ -25,6 +24,7 @@ from tools.triage.common import (
     get_cluster_logs_base_url,
     get_or_create_triage_ticket,
 )
+from tools.utils import days_ago
 
 DEFAULT_DAYS_TO_HANDLE = 30
 DEFAULT_DAYS_TO_ADD_SIGNATURES = 3

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,4 +1,11 @@
 import netrc
+from datetime import datetime
+
+import dateutil.parser
+
+
+def days_ago(datestr):
+    return (datetime.now() - dateutil.parser.isoparse(datestr)).days
 
 
 def get_credentials_from_netrc(*, hostname, netrc_file=None):


### PR DESCRIPTION
We plan on moving from the logs-collector server to a more maintainable and secure solution, being Jira attachments.

This change first creates Jira tickets as placeholder for each installation attempt (it no existing ticket can be found), archive and split the files (because Jira attachments have a size limit of 50MB) and continue with the rest of the process.

We shouldn't have lots of cases where we split the files (only 0.02% of the logs are more than 50MB), and for now this does not change the further processing through logs-collector server. Later on we'll create a method for reading Jira attachments and editing the signatures based on those.