### PR TITLE
Fix ccx installation missing openssl

### DIFF
--- a/Dockerfile.assisted-installer-deployment
+++ b/Dockerfile.assisted-installer-deployment
@@ -25,7 +25,7 @@ ARG INSTALL_CCX=true
 
 COPY ccx/ ./ccx
 RUN if [ "${INSTALL_CCX}" == "true" ]; then \
-        ./ccx/install.sh; \
+	dnf install -y openssl && ./ccx/install.sh; \
     fi
 
 WORKDIR /home/assisted-installer-deployment


### PR DESCRIPTION
Seems like currently the installation of insights fails because there's no ``openssl`` binary available to use:
```
16:40:06  ./ccx/install.sh: line 9: openssl: command not found
16:40:06    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
16:40:06                                   Dload  Upload   Total   Spent    Left  Speed
16:40:06  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  3145  100  3085  100    60   4237     82 --:--:-- --:--:-- --:--:--  4320
16:40:06  (23) Failed writing body
16:40:08  Collecting git+https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git (from -r ./ccx/requirements-rht.txt (line 1))
16:40:08    Cloning https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git to /tmp/pip-req-build-yhems_u9
16:40:08    Running command git clone --filter=blob:none --quiet https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git /tmp/pip-req-build-yhems_u9
16:40:09    fatal: unable to access 'https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git/': SSL certificate problem: self signed certificate in certificate chain
16:40:09    error: subprocess-exited-with-error
16:40:09    
16:40:09    × git clone --filter=blob:none --quiet https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git /tmp/pip-req-build-yhems_u9 did not run successfully.
16:40:09    │ exit code: 128
16:40:09    ╰─> See above for output.
16:40:09    
16:40:09    note: This error originates from a subprocess, and is likely not a problem with pip.
16:40:09  error: subprocess-exited-with-error
16:40:09  
16:40:09  × git clone --filter=blob:none --quiet https://gitlab.cee.redhat.com/ccx/ccx-ocp-core.git /tmp/pip-req-build-yhems_u9 did not run successfully.
16:40:09  │ exit code: 128
16:40:09  ╰─> See above for output.
16:40:09  
16:40:09  note: This error originates from a subprocess, and is likely not a problem with pip.
```

This installs the required dependency.