### PR TITLE
MGMT-13752: Fix description not filled in

### DIFF
--- a/tools/triage/common.py
+++ b/tools/triage/common.py
@@ -5,6 +5,7 @@ import jira
 
 JIRA_PROJECT = "AITRIAGE"
 JIRA_SUMMARY = "cloud.redhat.com failure: {failure_id}"
+LOGS_COLLECTOR = "http://assisted-logs-collector.usersys.redhat.com"
 
 log = logging.getLogger(__name__)
 
@@ -33,3 +34,7 @@ def get_or_create_triage_ticket(jira_client: jira.JIRA, failure_id: str) -> jira
     raise RuntimeError(
         f"Found more than one matching issue for '{summary}': {', '.join(issue.key for issue in matching_issues)}"
     )
+
+
+def get_cluster_logs_base_url(failure_id: str) -> str:
+    return f"{LOGS_COLLECTOR}/files/{failure_id}"

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -20,11 +20,10 @@ from tools.triage.add_triage_signature import (
     days_ago,
     process_ticket_with_signatures,
 )
-from tools.triage.common import get_or_create_triage_ticket
+from tools.triage.common import get_or_create_triage_ticket, LOGS_COLLECTOR, get_cluster_logs_base_url
 
 DEFAULT_DAYS_TO_HANDLE = 30
 DEFAULT_DAYS_TO_ADD_SIGNATURES = 3
-LOGS_COLLECTOR = "http://assisted-logs-collector.usersys.redhat.com"
 
 
 def close_custom_domain_user_ticket(jira_client, issue_key):
@@ -50,7 +49,7 @@ def main(args):
         if not args.all and days_ago_creation > DEFAULT_DAYS_TO_HANDLE:
             continue
 
-        logs_url = f"{LOGS_COLLECTOR}/files/{failure['name']}"
+        logs_url = get_cluster_logs_base_url(failure["name"])
 
         res = requests.get(f"{logs_url}/metadata.json")
         res.raise_for_status()


### PR DESCRIPTION
Back in
https://github.com/openshift-assisted/assisted-installer-deployment/pull/353 I acted on the assumption that filling-in the description right at ticket creation is not required, as later on we're activating the ``FailureDescription`` signature (which is what's filling-in the ticket description). It turns out that the code reads logs URL from the description, and that the signature doesn't apply by default.

This changes the code to be a bit more coherent around the source-of-truth for getting logs base URL, as well as making the signatures less dependent on each other.