### PR TITLE
Retry per ticket handling errors

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -27,6 +27,7 @@ import requests
 import tqdm
 from fuzzywuzzy import fuzz
 from tabulate import tabulate
+from retry import retry
 
 from tools import consts
 
@@ -2821,6 +2822,7 @@ def format_time(time_str):
     return dateutil.parser.isoparse(time_str).strftime("%Y-%m-%d %H:%M:%S")
 
 
+@retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10)
 def process_ticket_with_signatures(
     jira_client,
     ticket_logs_url,

--- a/tools/triage/common.py
+++ b/tools/triage/common.py
@@ -1,6 +1,7 @@
 import logging
 
 import jira
+from retry import retry
 
 
 JIRA_PROJECT = "AITRIAGE"
@@ -9,6 +10,7 @@ JIRA_SUMMARY = "cloud.redhat.com failure: {failure_id}"
 log = logging.getLogger(__name__)
 
 
+@retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10)
 def get_or_create_triage_ticket(jira_client: jira.JIRA, failure_id: str) -> jira.Issue:
     summary = JIRA_SUMMARY.format(failure_id=failure_id)
 

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -9,7 +9,6 @@ import os
 
 import jira
 import requests
-from retry import retry
 
 from tools import consts
 from tools.triage import close_by_signature
@@ -35,7 +34,6 @@ def close_custom_domain_user_ticket(jira_client, issue_key):
         jira_client.add_comment(issue, "Automatically closing the issue for the specified domain.")
 
 
-@retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10)
 def main(args):
     jira_client = jira.JIRA(consts.JIRA_SERVER, token_auth=args.jira_access_token, validate=True)
 


### PR DESCRIPTION
Seems like if we're having a single failure during processing of the tickets, we're going over all tickets again (even those that we already processed successfully).

This changes it to do the retries per ticket handling, to reduce the time needed.