### PR TITLE
append labels instead of resetting

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -691,9 +691,8 @@ class FailureDetails(Signature):
             # project
             cluster_md = extract_cluster_md_from_existing_labels(issue)
 
-        existing_labels = issue.fields.__dict__["labels"] or []
+        existing_labels = issue.fields.labels
 
-        logger.info(f"ISSUE {issue.key} existing labels: {existing_labels}")
         update_fields = {
             "labels": existing_labels,
         }

--- a/tools/triage/common.py
+++ b/tools/triage/common.py
@@ -14,7 +14,7 @@ def get_or_create_triage_ticket(jira_client: jira.JIRA, failure_id: str) -> jira
     summary = JIRA_SUMMARY.format(failure_id=failure_id)
 
     matching_issues = jira_client.search_issues(
-        f'project = "{JIRA_PROJECT}" AND summary ~ "{summary}"', fields=["attachment", "status"]
+        f'project = "{JIRA_PROJECT}" AND summary ~ "{summary}"', fields=["attachment", "status", "labels"]
     )
 
     if len(matching_issues) == 0:

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -68,6 +68,7 @@ def main(args):
             logger.debug("Skipping issue %s which is %d days old", issue.key, days_ago_creation)
             continue
 
+        logger.debug("Processing issue %s", issue.key)
         process_ticket_with_signatures(
             jira_client,
             logs_url,


### PR DESCRIPTION
Lables were being resets, so it was impossible to add fake labels for testing for example (or other signatures labels could've been wiped)