### PR TITLE
retry for jira errors when closing tickets

### DIFF
--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -9,6 +9,7 @@ import os
 
 import jira
 import requests
+from retry import retry
 
 from tools import consts
 from tools.triage import close_by_signature
@@ -25,6 +26,7 @@ DEFAULT_DAYS_TO_HANDLE = 30
 DEFAULT_DAYS_TO_ADD_SIGNATURES = 3
 
 
+@retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10)
 def close_custom_domain_user_ticket(jira_client, issue_key):
     issue = jira_client.issue(issue_key)
     if issue.raw["fields"].get(custom_field_name(CUSTOM_FIELD_DOMAIN)) in CUSTOM_FIELD_IGNORED_DOMAINS:


### PR DESCRIPTION
With current code we can get:
```
13:28:36  Traceback (most recent call last):
13:28:36    File
   "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/triage/create_triage_tickets.py",
line 114, in <module>
13:28:36      main(args)
13:28:36    File
   "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/triage/create_triage_tickets.py",
line 77, in main
13:28:36      close_custom_domain_user_ticket(jira_client, issue.key)
13:28:36    File
   "/mnt-assisted-log/workspace/download_logs/assisted-installer-deployment/./tools/triage/create_triage_tickets.py",
line 29, in close_custom_domain_user_ticket
13:28:36      issue = jira_client.issue(issue_key)
13:28:36              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/client.py",
line 1404, in issue
13:28:36      issue.find(id, params=params)
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/resources.py",
line 288, in find
13:28:36      self._load(url, params=params)
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/resources.py",
line 458, in _load
13:28:36      r = self._session.get(url, headers=headers, params=params)
13:28:36          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/resilientsession.py",
line 195, in get
13:28:36      return self.__verb("GET", str(url), **kwargs)
13:28:36             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/resilientsession.py",
line 189, in __verb
13:28:36      raise_on_error(response, verb=verb, **kwargs)
13:28:36    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/jira/resilientsession.py",
line 64, in raise_on_error
13:28:36      raise JIRAError(
13:28:36  jira.exceptions.JIRAError: JiraError HTTP 401 url:
```

and crash the program. This is because
https://github.com/openshift-assisted/assisted-installer-deployment/pull/355 doesn't retry globally anymore.