### PR TITLE
retry filter instantation if jira GET issue fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ black:
 
 format:
 	black tools/
+	isort --profile black tools/ tests/
 
 flake8:
 	flake8 .

--- a/tools/triage/filters.py
+++ b/tools/triage/filters.py
@@ -1,6 +1,9 @@
 import json
 import logging
 
+import retry
+from jira.exceptions import JIRAError
+
 from tools.jira_client import JiraAPI
 
 from .add_triage_signature import ALL_SIGNATURES
@@ -87,6 +90,7 @@ class SignatureFilter(Filter):
 
 class Filters:
     @staticmethod
+    @retry.retry(exceptions=JIRAError, tries=3, delay=2)
     def create_filter(jira_client, filter_type, identifier, root_issue_key, message):
         root_issue = jira_client.issue(root_issue_key)
 


### PR DESCRIPTION
This would retry if `jira.issue(key)` fails for some reason.

We definitely need a better strategy, this is just to make it resilient for now