### PR TITLE
pass issue key instead of issue object from jira dry run client to real jira client

### DIFF
--- a/tests/tools/jira/test_jira_dryrun_client.py
+++ b/tests/tools/jira/test_jira_dryrun_client.py
@@ -13,12 +13,6 @@ def devnull_stream():
         yield devnull
 
 
-def get_mock_issue(key="foobar"):
-    issue = Mock()
-    issue.key = key
-    return issue
-
-
 class MockAttributeErrorJiraClient:
     pass
 
@@ -42,7 +36,7 @@ def test_should_not_proxy_calls_to_real_jira_client_when_calling_create_issue_li
     mock_jira_client = Mock()
     mock_jira_client.create_issue_link = Mock(return_value=[])
     jira_dryrun_client = JiraDryRunClient(jira_client=mock_jira_client, dry_run_stream=devnull_stream)
-    jira_dryrun_client.create_issue_link(link_name="link_name", issue=get_mock_issue(), root_issue=get_mock_issue())
+    jira_dryrun_client.create_issue_link(link_name="link_name", issue_key="issue_key", root_issue_key="root_issue_key")
     mock_jira_client.create_issue_link.assert_not_called()
 
 
@@ -50,5 +44,5 @@ def test_should_not_proxy_calls_to_real_jira_client_when_calling_transition_issu
     mock_jira_client = Mock()
     mock_jira_client.transition_issue = Mock(return_value=[])
     jira_dryrun_client = JiraDryRunClient(jira_client=mock_jira_client, dry_run_stream=devnull_stream)
-    jira_dryrun_client.transition_issue(issue=get_mock_issue(), target_status=CLOSED_STATUS)
+    jira_dryrun_client.transition_issue(issue_key="issue_key", target_status=CLOSED_STATUS)
     mock_jira_client.transition_issue.assert_not_called()

--- a/tools/jira_client/jira_dryrun_client.py
+++ b/tools/jira_client/jira_dryrun_client.py
@@ -9,16 +9,16 @@ class JiraDryRunClient:
         except AttributeError:
             return getattr(self._jira_client, name)
 
-    def create_issue_link(self, link_name, issue, root_issue):
+    def create_issue_link(self, link_name, issue_key, root_issue_key):
         print(
-            f"Linked issue key={issue.key} as {link_name} root issue key={root_issue.key}\n",
+            f"Linked issue key={issue_key} as {link_name} root issue key={root_issue_key}\n",
             file=self._dry_run_stream,
             flush=True,
         )
 
-    def transition_issue(self, issue, target_status):
+    def transition_issue(self, issue_key, target_status):
         print(
-            f"Transitioned issue key={issue.issue.key} to {target_status}",
+            f"Transitioned issue key={issue_key} to {target_status}",
             file=self._dry_run_stream,
             flush=True,
         )


### PR DESCRIPTION
Fix by passing key instead mistakenly passed whole issue 