### PR TITLE
bump jira client to v3.4.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ requests==2.26.0
 ruamel.yaml==0.17.16
 PyGithub==1.55
 python-gitlab==2.10.1
-jira==3.1.1
+jira==3.4.1
 python-jenkins==1.7.0
 packaging==21.0
 tabulate==0.8.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,20 +8,16 @@ async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via pytest
-cachecontrol[filecache]==0.12.11
+cachecontrol==0.12.11
     # via insights-core
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
-    # via
-    #   cryptography
-    #   pynacl
+    # via pynacl
 charset-normalizer==2.0.12
     # via requests
 colorlog==4.7.2
     # via -r requirements.in
-cryptography==39.0.0
-    # via secretstorage
 decorator==4.4.2
     # via
     #   networkx
@@ -36,32 +32,18 @@ fuzzywuzzy==0.18.0
     # via -r requirements.in
 idna==3.4
     # via requests
-importlib-metadata==6.0.0
-    # via keyring
 iniconfig==2.0.0
     # via pytest
 insights-core==3.1.4
     # via -r requirements.in
-jaraco-classes==3.2.3
-    # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via insights-core
-jira==3.1.1
+jira==3.4.1
     # via -r requirements.in
-keyring==23.13.1
-    # via jira
 lockfile==0.12.2
-    # via
-    #   cachecontrol
-    #   insights-core
+    # via insights-core
 markupsafe==2.1.2
     # via jinja2
-more-itertools==9.0.0
-    # via jaraco-classes
 msgpack==1.0.4
     # via cachecontrol
 multi-key-dict==2.0.3
@@ -75,6 +57,7 @@ oauthlib==3.2.2
 packaging==21.0
     # via
     #   -r requirements.in
+    #   jira
     #   pytest
 pbr==5.11.1
     # via python-jenkins
@@ -134,8 +117,6 @@ retry==0.9.2
     # via -r requirements.in
 ruamel-yaml==0.17.16
     # via -r requirements.in
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   insights-core
@@ -147,12 +128,12 @@ tomli==2.0.1
     # via pytest
 tqdm==4.59.0
     # via -r requirements.in
+typing-extensions==4.5.0
+    # via jira
 urllib3==1.26.14
     # via requests
 wrapt==1.14.1
     # via deprecated
-zipp==3.12.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Newer jira client versions should only retry on 429 instead of 502, 503, 504, and 401 (including POST requests). This should be safer to do than current behavior.