### PR TITLE
Split long triage status reports

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,4 @@ pytest==7.1.1
 networkx==2.5.1
 insights-core>3.0.276
 pyfakefs==5.1.0
+slack_sdk==3.19.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ async-timeout==4.0.2
     # via redis
 attrs==22.2.0
     # via pytest
-cachecontrol==0.12.11
+cachecontrol[redis]==0.12.11
     # via insights-core
 certifi==2022.12.7
     # via requests
@@ -94,7 +94,9 @@ pyyaml==6.0
     #   -r requirements.in
     #   insights-core
 redis==4.4.2
-    # via insights-core
+    # via
+    #   cachecontrol
+    #   insights-core
 requests==2.26.0
     # via
     #   -r requirements.in
@@ -122,6 +124,8 @@ six==1.16.0
     #   insights-core
     #   python-dateutil
     #   python-jenkins
+slack-sdk==3.19.2
+    # via -r requirements.in
 tabulate==0.8.9
     # via -r requirements.in
 tomli==2.0.1


### PR DESCRIPTION
Slack is automatically splitting long messages (when it's more than 4040 characters long). Affects of this are not taht good, because it causes a malformed markdown format.

This change splits the report to several messages (one message after another. Unfortunately it's not seem possible to do in one thread when using webhooks and the webhook's client), when the table has more than 7 rows.
If there are 7 rows or less, it just fits it in one single message (as it's doing right now).

The change also leverages use of ``slack_sdk`` library, which should verify enable a better handling of requests and responses.