### PR TITLE
Fix arguments for jira methods

### DIFF
--- a/tests/tools/jira/test_jira_dryrun_client.py
+++ b/tests/tools/jira/test_jira_dryrun_client.py
@@ -13,12 +13,6 @@ def devnull_stream():
         yield devnull
 
 
-def get_mock_issue(key="foobar"):
-    issue = Mock()
-    issue.key = key
-    return issue
-
-
 class MockAttributeErrorJiraClient:
     pass
 
@@ -40,15 +34,13 @@ def test_should_proxy_calls_to_real_jira_when_calling_undefined_methods(devnull_
 
 def test_should_not_proxy_calls_to_real_jira_client_when_calling_create_issue_link(devnull_stream):
     mock_jira_client = Mock()
-    mock_jira_client.create_issue_link = Mock(return_value=[])
     jira_dryrun_client = JiraDryRunClient(jira_client=mock_jira_client, dry_run_stream=devnull_stream)
-    jira_dryrun_client.create_issue_link(link_name="link_name", issue=get_mock_issue(), root_issue=get_mock_issue())
+    jira_dryrun_client.create_issue_link("link_name", "issue", "root_issue")
     mock_jira_client.create_issue_link.assert_not_called()
 
 
 def test_should_not_proxy_calls_to_real_jira_client_when_calling_transition_issue(devnull_stream):
     mock_jira_client = Mock()
-    mock_jira_client.transition_issue = Mock(return_value=[])
     jira_dryrun_client = JiraDryRunClient(jira_client=mock_jira_client, dry_run_stream=devnull_stream)
-    jira_dryrun_client.transition_issue(issue=get_mock_issue(), target_status=CLOSED_STATUS)
+    jira_dryrun_client.transition_issue(issue="issue", target_status=CLOSED_STATUS)
     mock_jira_client.transition_issue.assert_not_called()

--- a/tools/jira_client/jira_api.py
+++ b/tools/jira_client/jira_api.py
@@ -1,12 +1,12 @@
 import retry
-from jira.exceptions import JIRAError
+from jira import JIRA, JIRAError
 
 from .consts import CLOSED_STATUS
 
 
 class JiraAPI:
     def __init__(self, jira_client, logger) -> None:
-        self._jira_client = jira_client
+        self._jira_client: JIRA = jira_client
         self._logger = logger
 
     def link_issue_to_root_issue(self, issue, root_issue):

--- a/tools/jira_client/jira_dryrun_client.py
+++ b/tools/jira_client/jira_dryrun_client.py
@@ -9,16 +9,16 @@ class JiraDryRunClient:
         except AttributeError:
             return getattr(self._jira_client, name)
 
-    def create_issue_link(self, link_name, issue, root_issue):
+    def create_issue_link(self, link_name: str, issue_key: str, root_issue_key: str):
         print(
-            f"Linked issue key={issue.key} as {link_name} root issue key={root_issue.key}\n",
+            f"Linked issue key={issue_key} as {link_name} root issue key={root_issue_key}\n",
             file=self._dry_run_stream,
             flush=True,
         )
 
-    def transition_issue(self, issue, target_status):
+    def transition_issue(self, issue: str, target_status: str):
         print(
-            f"Transitioned issue key={issue.issue.key} to {target_status}",
+            f"Transitioned issue key={issue} to {target_status}",
             file=self._dry_run_stream,
             flush=True,
         )

--- a/tools/jira_cmd.py
+++ b/tools/jira_cmd.py
@@ -194,8 +194,7 @@ class JiraTool:
     def link_tickets(self, ticket, to_ticket):
         try:
             logger.info("linking %s to %s", to_ticket.key, ticket.key)
-            res = self._jira.create_issue_link("relates to", ticket, to_ticket)
-            res.raise_for_status()
+            self._jira.create_issue_link("relates to", ticket.key, to_ticket.key)
         except Exception:
             logger.exception("Error linking to %s", to_ticket.key)
 

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -35,8 +35,8 @@ def close_custom_domain_user_ticket(jira_client, issue_key):
     issue = jira_client.issue(issue_key)
     if issue.raw["fields"].get(custom_field_name(CUSTOM_FIELD_DOMAIN)) in CUSTOM_FIELD_IGNORED_DOMAINS:
         logger.info("closing custom user's issue: %s", issue_key)
-        jira_client.transition_issue(issue, CLOSED_STATUS)
-        jira_client.add_comment(issue, "Automatically closing the issue for the specified domain.")
+        jira_client.transition_issue(issue_key, CLOSED_STATUS)
+        jira_client.add_comment(issue_key, "Automatically closing the issue for the specified domain.")
 
 
 def main(args):


### PR DESCRIPTION
Seems like we had a few competing notions for jira actions: providing issue objects or their corresponding keys.

It lead to errors like:
```
self._jira_client.create_issue_link("is related to", issue_key,
ticket.key)
  File
"/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/tools/jira_client/jira_dryrun_client.py",
line 14, in create_issue_link
    f"Linked issue key={issue.key} as {link_name} root issue
key={root_issue.key}\n",
                        ^^^^^^^^^
AttributeError: 'str' object has no attribute 'key'
```

This fixes the issue by changing it all to issue keys arguments, as it is also the behavior of the vanilla Jira client.