### PR TITLE
fix references to the new assisted-installer UI repo name

### DIFF
--- a/assisted-installer.yaml
+++ b/assisted-installer.yaml
@@ -11,7 +11,7 @@ openshift/assisted-service:
   - backend
   images:
   - quay.io/edge-infrastructure/assisted-service
-openshift-assisted/assisted-ui:
+openshift-assisted/assisted-installer-ui:
   categories:
   - frontend
   revision: c05464490fcdafd7164c9b96828c8a6795784689

--- a/tools/release_tickets.py
+++ b/tools/release_tickets.py
@@ -176,8 +176,6 @@ def main(
 
         for repo, _ in to_manifest.items():
             if not requested_repos or os.path.basename(repo) in requested_repos:
-                if repo == "openshift-assisted/assisted-ui" and from_commit == "v1.0.12.1":
-                    continue
                 repo_to_commit = get_commit_from_manifest(to_manifest, repo)
                 repo_from_commit = get_commit_from_manifest(from_manifest, repo)
                 keys = get_issues_list_for_repo(repo, repo_from_commit, repo_to_commit)
@@ -261,7 +259,7 @@ if __name__ == "__main__":
         "assisted-installer",
         "assisted-service",
         "assisted-installer-agent",
-        "assisted-ui",
+        "assisted-installer-ui",
         "assisted-image-service",
     ]
     parser = argparse.ArgumentParser()

--- a/tools/update_assisted_installer_yaml.py
+++ b/tools/update_assisted_installer_yaml.py
@@ -51,7 +51,7 @@ def main():
         deployment = yaml.safe_load(f)
 
     for rep in deployment:
-        if rep == "openshift-assisted/assisted-ui":
+        if rep == "openshift-assisted/assisted-installer-ui":
             # for UI we're only updating when new releases are being published
             github_client = github.Github()
             ui_repo = github_client.get_repo(rep)


### PR DESCRIPTION
UI team expects a change in their repositories, moving to one monorepo that should contain all UI components related to assisted-installer: core logic (``openshift-assisted/assisted-ui-lib``), dev/podman (``openshift-assisted/assisted-ui``), BILLI, etc.

This mirror the changes to the new repo name.