### PR TITLE
Fix duplicated Jira attachments

### DIFF
--- a/tools/jira_client/jira_client_factory.py
+++ b/tools/jira_client/jira_client_factory.py
@@ -9,7 +9,7 @@ from .jira_dryrun_client import JiraDryRunClient
 class JiraClientFactory:
     @staticmethod
     def create(jira_access_token, dry_run_stream=None, validate=True):
-        client = jira.JIRA(server=consts.JIRA_SERVER, token_auth=jira_access_token, validate=validate)
+        client = jira.JIRA(server=consts.JIRA_SERVER, token_auth=jira_access_token, validate=validate, max_retries=0)
         if dry_run_stream is not None:
             client = JiraDryRunClient(client, dry_run_stream)
         return client


### PR DESCRIPTION
Due to the retry mechanism of the Jira client, sometimes we can get into transient errors from the server that makes the client re-send attachments (or do any kind of POST request).

This bypasses the idempotent mechanism implemented in our code, one example is: https://github.com/openshift-assisted/assisted-installer-deployment/blob/036ed3a555abd3dc33c69f74ca42674a6d526aae/tools/triage/attach_logs_in_jira.py#L64-L69