### PR TITLE
Fix a few things for the auto jira tagger

### DIFF
--- a/tools/release_tickets.py
+++ b/tools/release_tickets.py
@@ -13,7 +13,9 @@ from collections import defaultdict
 import yaml
 from tabulate import tabulate
 
+from tools.consts import JIRA_SERVER
 from tools.jira_client import JiraClientFactory
+from tools.utils import get_credentials_from_netrc
 
 logging.basicConfig(level=logging.WARN, format="%(levelname)-10s %(message)s")
 logger = logging.getLogger(__name__)
@@ -259,7 +261,6 @@ if __name__ == "__main__":
         "assisted-installer",
         "assisted-service",
         "assisted-installer-agent",
-        "assisted-installer-ui",
         "assisted-image-service",
     ]
     parser = argparse.ArgumentParser()
@@ -352,7 +353,12 @@ if __name__ == "__main__":
     if args.verbose:
         logger.setLevel(logging.DEBUG)
 
-    jclient = JiraClientFactory.create(args.jira_access_token)
+    if args.jira_access_token:
+        jira_access_token = args.jira_access_token
+    else:
+        _, jira_access_token = get_credentials_from_netrc(hostname=JIRA_SERVER)
+
+    jclient = JiraClientFactory.create(jira_access_token)
 
     main(
         jclient,


### PR DESCRIPTION
A few fixes that are required for ``skipper run python3 tools/release_tickets.py``:
* Ignoring the UI repository (it was renamed recently which causes it failures in comparing with old versions)
* Getting Jira password from netrc file if other ways didn't work