### PR TITLE
NO-ISSUE: Match only ssh/console logins to avoid false positives

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -2539,7 +2539,7 @@ class UserHasLoggedIntoCluster(Signature):
     This signature will detect user login to the cluster.
     """
 
-    USER_LOGIN_PATTERN = re.compile(r"session opened for user .+ by")
+    USER_LOGIN_PATTERN = re.compile(r"pam_unix\((sshd|login):session\): session opened for user .+ by")
 
     def __init__(self, *args, **kwargs):
         super().__init__(


### PR DESCRIPTION
Currently we have many false positives created by scripts
Refining the regex to match only ssh/console logins might be a better option

Example lines that trigger false positives:
````
Jun 07 10:28:43 random-hostname sudo[36402]: pam_unix(sudo:session): session opened for user root by (uid=0)
Jun 07 10:48:59 random-hostname systemd[47398]: pam_unix(systemd-user:session): session opened for user root by (uid=0)
Jun 07 10:48:59 random-hostname sudo[47341]: pam_unix(sudo:session): session opened for user root by (uid=0)
Jun 07 10:48:59 random-hostname sudo[47347]: pam_unix(sudo:session): session opened for user root by (uid=0)
Jun 07 10:48:59 random-hostname sudo[47351]: pam_unix(sudo:session): session opened for user root by (uid=0)
````