### PR TITLE
Match more possible controller log file names

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -209,7 +209,7 @@ def get_triage_logs_tar(triage_url, cluster_id):
 
 def get_controller_logs(triage_url):
     return get_triage_logs_tar(triage_url=triage_url, cluster_id=get_metadata_json(triage_url)["cluster"]["id"]).get(
-        "controller_logs.tar.gz/assisted-installer-controller-*.logs"
+        "controller_logs.tar.gz/assisted-installer-controller*.logs"
     )
 
 


### PR DESCRIPTION
Before this some controller logs were getting missed because they were named just `assisted-installer-controller.logs` without any `-`.

This meant that signatures like the one for UMN and LB-related operator failures were not being run.

cc @omertuc @paul-maidment @rccrdpccl 