### PR TITLE
Add signature for cases where the cluster moved from installing pending user action to error

### DIFF
--- a/tools/triage/triage_resolving_filters.json
+++ b/tools/triage/triage_resolving_filters.json
@@ -7,6 +7,9 @@
   "labels": {
     "FEATURE-Validations-have-been-ignored-for-this-cluster": {
       "MGMT-13442": "Clusters on which validations are ignored are unsupported."
+    },
+   "SIGNATURE_pending_user_action": {
+     "MGMT-15127": "No need to triage installation failure due to timeout while pending user action."
     }
   }
 }


### PR DESCRIPTION

We can probably close these tickets since the installation failed because the user didn't act and fixed the hardware issue (usually boot the hosts from the right disk) within the installation timeout