### PR TITLE
NO-ISSUE: Fix DeletedHostsStatusSignature so it only triggers when needed

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -585,6 +585,9 @@ class DeletedHostsStatusSignature(Signature):
     def _process_ticket(self, url, issue_key):
         md = get_metadata_json(url)
 
+        if len(md["cluster"]["deleted_hosts"]) < 1:
+            return
+
         hosts = []
         for host in md["cluster"]["deleted_hosts"]:
             info = host["status_info"]


### PR DESCRIPTION
The signature was always triggering a message, with this it should only do when there are deleted_hosts