### PR TITLE
Don't hide the more controller warnings message inside the code block at the bottom

### DIFF
--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -2633,13 +2633,11 @@ class ControllerWarnings(Signature):
         warnings = warnings_from_controller_logs(controller_logs)
         if len(warnings) != 0:
             warning_text = "\n".join(warnings[:max_shown])
-
+            warning_text = f"{{code}}{warning_text}{{code}}"
             if len(warnings) > max_shown:
-                warning_text += (
-                    "\n" + f"There are {len(warnings) - max_shown} additional warnings but they are not shown"
-                )
+                warning_text = f"{warning_text}\nh1. *{{color:red}}There are {len(warnings) - max_shown} additional warnings but they are not shown{{color}}*"
 
-            self._update_triaging_ticket("Controller logs contain some warnings:\n" + f"{{code}}{warning_text}{{code}}")
+            self._update_triaging_ticket(f"Controller logs contain some warnings:\n{warning_text}")
 
 
 class UserHasLoggedIntoCluster(Signature):


### PR DESCRIPTION
![image](https://github.com/openshift-assisted/assisted-installer-deployment/assets/10882062/8c98a935-53af-466d-a55b-447eefd16c84)

vs

![image](https://github.com/openshift-assisted/assisted-installer-deployment/assets/10882062/1f3f9173-1795-4cbd-9189-40231736c464)
