### PR TITLE
MGMT-13876: Cleaning old issues attachments and watchers

### DIFF
--- a/Jenkinsfile.clean_old_issues
+++ b/Jenkinsfile.clean_old_issues
@@ -1,0 +1,53 @@
+pipeline {
+    agent any
+
+    triggers { cron('H 12 * * *') }
+
+    parameters {
+        string(name: 'ASSISTED_TEST_INFRA_REMOTE', defaultValue: 'https://github.com/openshift/assisted-test-infra', description: 'assisted-test-infra repo URL to use')
+        string(name: 'ASSISTED_TEST_INFRA_BRANCH', defaultValue: 'master', description: 'Branch on assisted-test-infra repo to use')
+        string(name: 'ASSISTED_INSTALLER_DEPLOYMENT_REMOTE', defaultValue: 'https://github.com/openshift-assisted/assisted-installer-deployment', description: 'assisted-installer-deployment repo URL to use')
+        string(name: 'ASSISTED_INSTALLER_DEPLOYMENT_BRANCH', defaultValue: 'master', description: 'Branch on assisted-installer-deployment repo to use')
+        string(name: 'LOG_LEVEL', defaultValue: 'INFO', description: 'Log level')
+        string(name: 'DAYS', defaultValue: '180', description: 'Age from which tickets are considered old and will be addressed in days')
+        string(name: 'ISSUES_LIMIT', defaultValue: '50', description: 'Maximum number of issues to update')
+    }
+
+    environment {
+        JIRA_ACCESS_TOKEN = credentials('assisted-installer-bot-jira-access-token')
+        SLACK_TOKEN = credentials('slack-token')
+    }
+
+    stages {
+        stage('Init') {
+            steps {
+                sh "rm -rf assisted-test-infra"
+                sh "git clone ${ASSISTED_TEST_INFRA_REMOTE} --branch ${ASSISTED_TEST_INFRA_BRANCH}"
+                dir ('assisted-test-infra') {
+                    sh "scripts/install_environment.sh install_skipper"
+                }
+
+                sh "rm -rf assisted-installer-deployment"
+                sh "git clone ${ASSISTED_INSTALLER_DEPLOYMENT_REMOTE} --branch ${ASSISTED_INSTALLER_DEPLOYMENT_BRANCH}"
+            }
+        }
+
+        stage('Delete old issues') {
+            steps {
+                dir ('assisted-installer-deployment') {
+                    sh "skipper run clean_old_issues --days ${DAYS} --issues-limit ${ISSUES_LIMIT} --log-level ${LOG_LEVEL} --jira-access-token ${JIRA_ACCESS_TOKEN}"
+                }
+            }
+        }
+    }
+
+    post {
+        failure {
+            script {
+                def data = [text: "Attention! ${BUILD_TAG} job failed, see: ${BUILD_URL}"]
+                writeJSON(file: 'data.txt', json: data, pretty: 4)
+            }
+            sh '''curl -X POST -H 'Content-type: application/json' --data-binary "@data.txt"  https://hooks.slack.com/services/${SLACK_TOKEN}'''
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,11 @@
 line-length = 120
 target-version = ['py310']
 include = '\.pyi?$'
+
+[project]
+name = "assisted_installer_deployment"
+description = "CI/CD tools for Assisted Installer related operations"
+version = "0.0.0"
+
+[project.scripts]
+clean_old_issues = "tools.triage.clean_old_issues:main"

--- a/tests/tools/triage/test_clean_old_issues.py
+++ b/tests/tools/triage/test_clean_old_issues.py
@@ -1,0 +1,104 @@
+from typing import Optional
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tools.triage import clean_old_issues
+
+
+def create_mock_attachment(identifier: int, filename: str) -> MagicMock:
+    attachment_mock = MagicMock()
+    attachment_mock.id = identifier
+    attachment_mock.filename = filename
+    return attachment_mock
+
+
+def create_mock_issue(key: str, attachments: Optional[list[MagicMock]] = None) -> MagicMock:
+    issue_mock = MagicMock()
+    issue_mock.key = key
+    issue_mock.fields.summary = "test summary"
+    issue_mock.fields.description = "test description"
+    issue_mock.fields.assignee = "test assignee"
+    issue_mock.fields.attachment = attachments
+
+    return issue_mock
+
+
+def create_mock_watcher(name: str) -> MagicMock:
+    watcher_mock = MagicMock()
+    watcher_mock.name = name
+    watcher_mock.email = f"{name}@test.com"
+    return watcher_mock
+
+
+@pytest.fixture(autouse=True)
+def jira_client() -> MagicMock:
+    with patch("tools.triage.clean_old_issues.JiraClientFactory") as jira_mock:
+        yield jira_mock.create()
+
+
+@pytest.fixture()
+def jira_issues() -> list[MagicMock]:
+    return [
+        create_mock_issue(key="AITRIAGE-1111"),
+        create_mock_issue(key="AITRIAGE-2222", attachments=[create_mock_attachment(filename="test filename 2", identifier=2)]),
+        create_mock_issue(key="AITRIAGE-3333", attachments=[create_mock_attachment(filename="test filename 3", identifier=3)]),
+    ]
+
+
+@pytest.fixture()
+def jira_watchers() -> list[MagicMock]:
+    mock_watchers = MagicMock()
+    mock_watchers.watchers = [create_mock_watcher("foo"), create_mock_watcher("bar")]
+    return mock_watchers
+
+
+def test_wrong_options():
+    with patch(
+        "sys.argv",
+        [
+            "clean_old_tickets_attachments",
+            "--days",
+            "<days-which-are-not-a-number>",
+            "--jira-access-token",
+            "<jira-client-token>",
+        ],
+    ):
+        with pytest.raises(SystemExit):
+            clean_old_issues.main()
+
+
+def test_full_flow(
+    jira_client: MagicMock,
+    jira_issues: list[MagicMock],
+    jira_watchers: list[MagicMock],
+):  # pylint: disable=W0621
+    with patch(
+        "sys.argv",
+        [
+            "clean_old_tickets_attachments",
+            "--days",
+            "180",
+            "--jira-access-token",
+            "<jira-client-token>",
+        ],
+    ):
+        jira_client.search_issues.return_value = [issue for issue in jira_issues if issue.fields.attachment]
+        jira_client.watchers.side_effect = lambda issue: jira_watchers if issue.key == "AITRIAGE-2222" else MagicMock()
+        jira_client.remove_watcher.return_value = MagicMock()
+        jira_client.transition_issue.return_value = MagicMock()
+
+        clean_old_issues.main()
+
+        jira_client.search_issues.assert_called_with(
+            "project = AITRIAGE AND attachments IS NOT EMPTY AND created <= -180d", maxResults=50
+        )
+        assert jira_client.watchers.call_args_list[0] == call(jira_issues[1])
+        assert jira_client.watchers.call_args_list[1] == call(jira_issues[2])
+
+        assert jira_client.remove_watcher.call_count == 2
+
+        assert jira_client.delete_attachment.call_args_list[0] == call(jira_issues[1].fields.attachment[0].id)
+        assert jira_client.delete_attachment.call_args_list[1] == call(jira_issues[2].fields.attachment[0].id)
+
+        assert jira_client.transition_issue.call_count == 2

--- a/tools/triage/clean_old_issues.py
+++ b/tools/triage/clean_old_issues.py
@@ -1,0 +1,167 @@
+import argparse
+import logging
+import os
+from typing import Final
+
+import jira
+
+from tools.jira_client import JiraClientFactory
+from tools.jira_client.consts import CLOSED_STATUS
+from tools.triage.common import JIRA_PROJECT
+
+LOG_LEVEL_DEFAULT: Final[str] = "INFO"
+ISSUES_LIMIT_DEFAULT: Final[int] = 50
+DAYS_DEFAULT: Final[int] = 180
+
+
+def get_logger(log_level: str) -> logging.Logger:
+    """
+    Args:
+        log_level: log level
+
+    Returns:
+        formatted logger with log-level.
+    """
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+def fetch_issues_from_jira(
+    jira_client: jira.JIRA,
+    jira_project_key: str,
+    logger: logging.Logger,
+    created_before: int = DAYS_DEFAULT,
+    issues_limit: int = ISSUES_LIMIT_DEFAULT,
+) -> list[jira.Issue]:
+    """Fetches and returns all issues from a given Jira project which created at least created_before days.
+
+    Args:
+        jira_client: Jira client for interacting with Jira API.
+        jira_project_key: Jira Project's key to fetch issues from.
+        logger: Logger.
+        created_before: Created before at least created_before days old.
+        issues_limit: Maximum number of issues.
+
+    Returns:
+        list of matching issues.
+    """
+
+    result_list = jira_client.search_issues(
+        f"project = {jira_project_key} AND attachments IS NOT EMPTY AND created <= -{created_before}d",
+        maxResults=issues_limit,
+    )
+    logger.info(f"Found {len(result_list)} issues")
+
+    return list(result_list)
+
+
+def update_issues(jira_client: jira.JIRA, issues: list[jira.Issue], logger: logging.Logger):
+    """Removes watchers & attachments from given issues and then closes them.
+
+    Args:
+        jira_client: Jira client for interacting with Jira API.
+        issues: Given issues.
+        logger: Logger.
+
+    Raises:
+        ExceptionGroup: when jira client fails to remove a watcher or attachment from an issue, or when it fails to close an issue.
+    """
+
+    errors = []
+
+    for issue in issues:
+        for watcher in jira_client.watchers(issue).watchers:
+            try:
+                jira_client.remove_watcher(issue.key, watcher.name)
+                logger.debug(f"Removed watcher {watcher.name} from issue {issue.key}.")
+            except jira.JIRAError as e:
+                logger.debug(f"Failed to remove watcher {watcher.name} from issue {issue.key}: ", exc_info=str(e))
+                errors.append(e)
+
+        for attachment in issue.fields.attachment:
+            try:
+                jira_client.delete_attachment(attachment.id)
+                logger.debug(f"Removed attachment {attachment.filename} from issue {issue.key}.")
+            except jira.JIRAError as e:
+                logger.debug(
+                    f"Failed to remove attachment {attachment.filename} from issue {issue.key}: ", exc_info=str(e)
+                )
+                errors.append(e)
+
+        try:
+            jira_client.transition_issue(issue.key, CLOSED_STATUS)
+            logger.debug(f"Closed issue {issue.key}.")
+        except jira.JIRAError as e:
+            logger.debug(f"Failed to close issue {issue.key}:", exc_info=str(e))
+            errors.append(e)
+
+    if errors:
+        for error in errors:
+            logger.exception("Error while updating issue in Jira.", exc_info=error)
+        raise ExceptionGroup("Failed to update all issues.", errors)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Removing watchers & attachments from old issues and then closing them."
+    )
+    parser.add_argument(
+        "--jira-access-token",
+        type=str,
+        default=os.environ.get("JIRA_ACCESS_TOKEN"),
+        required=False,
+        help="Personal access token for accessing Jira.",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=DAYS_DEFAULT,
+        required=False,
+        help="Age from which tickets are considered old and will be addressed in days.",
+    )
+    parser.add_argument(
+        "--issues-limit",
+        type=int,
+        default=ISSUES_LIMIT_DEFAULT,
+        required=False,
+        help="Maximum number of issues to update.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default=LOG_LEVEL_DEFAULT,
+        required=False,
+        help="Log level",
+    )
+
+    args = parser.parse_args()
+
+    logger = get_logger(args.log_level.upper())
+
+    if args.jira_access_token is None:
+        raise RuntimeError("No Jira access token was given.")
+
+    jira_client = JiraClientFactory.create(jira_access_token=args.jira_access_token)
+
+    issues = fetch_issues_from_jira(
+        jira_client=jira_client,
+        jira_project_key=JIRA_PROJECT,
+        created_before=args.days,
+        logger=logger,
+        issues_limit=args.issues_limit,
+    )
+
+    update_issues(jira_client=jira_client, issues=issues, logger=logger)
+
+    logger.info("Successfully updated issues:")
+    for issue in issues:
+        logger.info(issue.key)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
During the transition of triage issue creation from `Jenkins` to `Gitlab-CI`, and specifically in our effort to attach cluster logs as `Jira` attachments, we are planning to introduce a job to clear out outdated cluster logs which will help liberate unnecessary space in `Jira`. To avoid sending notifications, we will first remove the issue's watchers.