### PR TITLE
MGMT-13402: Using Jira attachments to produce ticket signatures

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -7,13 +7,15 @@ pipeline {
         string(name: 'ASSISTED_INSTALLER_DEPLOYMENT_BRANCH', defaultValue: 'master', description: 'Branch on assisted-installer-deployment repo to use')
         string(name: 'ASSISTED_TEST_INFRA_REMOTE', defaultValue: 'https://github.com/openshift/assisted-test-infra', description: 'assisted-test-infra repo URL to use')
         string(name: 'ASSISTED_TEST_INFRA_BRANCH', defaultValue: 'master', description: 'Branch on assisted-test-infra repo to use')
+        choice(name: 'SIGNATURES_SOURCE', choices: ['logs_server', 'jira'], description: 'Signatures will get created from the specified data source')
+        booleanParam(name: 'DRY_RUN', defaultValue: false, description: 'Flag to determine whether to run in dry run mode')
     }
 
     triggers { cron('H/30 * * * *') }
 
     environment {
         SKIPPER_PARAMS = " "
-
+        SIGNATURES_SOURCE = "${params.SIGNATURES_SOURCE}"
         LOGS_DEST = "/var/ai-logs/triage_logs"
 
         // Credentials
@@ -56,7 +58,10 @@ pipeline {
         stage('Create tickets') {
             steps {
                 dir ('assisted-installer-deployment') {
-                  sh 'skipper run -e PULL_SECRET_CONTENTS ./tools/triage/create_triage_tickets.py --jira-access-token ${JIRA_ACCESS_TOKEN} -v'
+                    script {
+                        def dryRunFlag = params.DRY_RUN ? '--dry-run' : ''
+                        sh "skipper run -e PULL_SECRET_CONTENTS -e SIGNATURES_SOURCE ./tools/triage/create_triage_tickets.py --jira-access-token ${JIRA_ACCESS_TOKEN} -v ${dryRunFlag}"
+                    }     
                 }
             }
         }

--- a/tests/tools/triage/utils/test_jira_remote_archive_querier.py
+++ b/tests/tools/triage/utils/test_jira_remote_archive_querier.py
@@ -1,0 +1,218 @@
+import io
+import tarfile
+import textwrap
+from unittest.mock import Mock
+
+import pytest
+
+from tools.triage.utils.extraction.jira_attachment_querier.jira_remote_archive_querier import (
+    JiraAttachmentsQuerier,
+)
+
+JIRA_ISSUE_KEY = "AITRIAGE-99999"
+
+
+@pytest.fixture
+def metadata_attachment() -> Mock:
+
+    metadata_attachment_mock = Mock()
+    metadata_attachment_mock.filename = "metadata.json"
+    metadata_attachment_mock.get.return_value = textwrap.dedent("""\
+        {
+            "name": "Foo Bar",
+            "age": "30",
+            "city": "New York",
+        }
+    """).encode()
+
+    return metadata_attachment_mock
+
+
+@pytest.fixture
+def cluster_files_attachment() -> Mock:
+
+    tar_buffer = io.BytesIO()
+
+    with tarfile.open(fileobj=tar_buffer, mode='w') as tar:
+        file1_content = io.BytesIO(b"Content of file1.txt")
+        file2_content = io.BytesIO(b"Content of file2.txt")
+
+        file1_info = tarfile.TarInfo(name='file1.txt')
+        file1_info.size = len(file1_content.getvalue())
+
+        file2_info = tarfile.TarInfo(name='file2.txt')
+        file2_info.size = len(file2_content.getvalue())
+
+        tar.addfile(file1_info, file1_content)
+        tar.addfile(file2_info, file2_content)
+
+    tar_buffer.seek(0)
+
+    cluster_files_attachment_mock = Mock()
+    cluster_files_attachment_mock.filename = "cluster_files.tar.gz"
+    cluster_files_attachment_mock.get.return_value = tar_buffer.getvalue()
+
+    return cluster_files_attachment_mock
+
+
+@pytest.fixture
+def jira_issue(metadata_attachment: Mock, cluster_files_attachment: Mock) -> Mock:
+    return Mock(key=JIRA_ISSUE_KEY, fields=Mock(attachment=[metadata_attachment, cluster_files_attachment]))
+
+
+@pytest.fixture(autouse=True)
+def jira_client(jira_issue: Mock) -> Mock:
+
+    def get_issue(issue_key: str) -> Mock:
+        match issue_key:
+            case "AITRIAGE-99999":
+                return jira_issue
+            case _:
+                return None
+
+    jira_client_mock = Mock()
+    jira_client_mock.issue.side_effect = get_issue
+    return jira_client_mock
+
+
+def test_init_with_existing_issue_should_be_successfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "metadata.json",
+        Mock()
+    )
+
+    assert querier.downloaded
+    assert not querier.extracted
+
+
+def test_init_with_non_existing_issue_should_be_unsuccessfull(jira_client):
+    with pytest.raises(Exception):
+        JiraAttachmentsQuerier(
+            jira_client,
+            "non-existing-issue",
+            "metadata.json",
+            Mock()
+        )
+
+
+def test_init_download_with_existing_attachment_should_be_successfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "metadata.json",
+        Mock()
+    )
+
+    assert querier.downloaded
+    assert not querier.extracted
+
+
+def test_init_download_with_non_existing_attachment_should_be_unsuccessfull(jira_client):
+    with pytest.raises(Exception):
+        JiraAttachmentsQuerier(
+            jira_client,
+            JIRA_ISSUE_KEY,
+            "non_existent_file.json",
+            Mock()
+        )
+
+
+def test_init_extraction_with_archive_path_should_be_successfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "cluster_files.tar.gz",
+        Mock(),
+        True
+    )
+
+    assert querier.downloaded
+    assert querier.extracted
+
+
+def test_init_extraction_with_non_archive_path_should_be_unsuccessfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "metadata.json",
+        Mock(),
+        True
+    )
+
+    assert querier.downloaded
+    assert not querier.extracted
+
+
+def test_get_with_non_archive_attachment_should_be_successfull(jira_client, metadata_attachment):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "metadata.json",
+        Mock()
+    )
+
+    content = querier.get()
+    expected_content = metadata_attachment.get().decode()
+    assert content == expected_content
+
+
+def test_get_with_existing_pattern_should_be_successfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "cluster_files.tar.gz",
+        Mock()
+    )
+
+    # text mode
+    content = querier.get("file1.txt")
+    assert content == "Content of file1.txt"
+
+    # bytes mode
+    content = querier.get("file1.txt", mode="rb")
+    assert content == b"Content of file1.txt"
+
+
+def test_get_with_non_existing_pattern_should_be_unsuccessfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "cluster_files.tar.gz",
+        Mock()
+    )
+
+    with pytest.raises(FileNotFoundError):
+        querier.get("non_existent_file.txt")
+
+
+def test_get_from_extracted_archive_with_existing_pattern_should_be_successfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "cluster_files.tar.gz",
+        Mock(),
+        True
+    )
+
+    # text mode
+    content = querier.get("file1.txt", from_extracted_tar=True)
+    assert content == "Content of file1.txt"
+
+    # bytes mode
+    content = querier.get("file1.txt", mode="rb", from_extracted_tar=True)
+    assert content == b"Content of file1.txt"
+
+
+def test_get_from_extracted_archive_with_non_existing_pattern_should_be_unsuccessfull(jira_client):
+    querier = JiraAttachmentsQuerier(
+        jira_client,
+        JIRA_ISSUE_KEY,
+        "cluster_files.tar.gz",
+        Mock(),
+        True
+    )
+
+    with pytest.raises(FileNotFoundError):
+        querier.get("non_existent_file.txt", from_extracted_tar=True)

--- a/tests/tools/triage/utils/test_local_nested_archive_extractor.py
+++ b/tests/tools/triage/utils/test_local_nested_archive_extractor.py
@@ -1,0 +1,153 @@
+import gzip
+import os
+import tarfile
+from io import BytesIO
+from pathlib import Path
+
+from tools.triage.utils.extraction.jira_attachment_querier.local_nested_archive_extractor import (
+    LocalNestedArchiveExtractor,
+)
+
+
+def create_in_memory_tar(files: dict) -> BytesIO:
+    buffer = BytesIO()
+
+    with tarfile.open(fileobj=buffer, mode='w') as tar:
+        for name, content in files.items():
+
+            if isinstance(content, (str, bytes)):
+                content_bytes = content if isinstance(content, bytes) else content.encode()
+                tarinfo = tarfile.TarInfo(name=name)
+                tarinfo.size = len(content_bytes)
+                tarinfo.mode = 0o644
+                tar.addfile(tarinfo, BytesIO(content_bytes))
+
+            elif isinstance(content, dict):
+                tarinfo = tarfile.TarInfo(name=name)
+                tarinfo.type = tarfile.DIRTYPE
+                tarinfo.mode = 0o755
+                tar.addfile(tarinfo)
+
+                for sub_name, sub_content in content.items():
+                    sub_content_bytes = sub_content if isinstance(sub_content, bytes) else sub_content.encode()
+                    tarinfo = tarfile.TarInfo(name=os.path.join(name, sub_name))
+                    tarinfo.size = len(sub_content_bytes)
+                    tarinfo.mode = 0o644
+                    tar.addfile(tarinfo, BytesIO(sub_content_bytes))
+
+    buffer.seek(0)
+    return buffer
+
+
+def create_in_memory_gz(content: str) -> BytesIO:
+    buffer = BytesIO()
+
+    with gzip.GzipFile(fileobj=buffer, mode='wb') as gnu_zip:
+        gnu_zip.write(content.encode())
+
+    buffer.seek(0)
+    return buffer
+
+
+def create_nested_tar(level: int) -> BytesIO:
+    def create_tar_with_file(level):
+        return create_in_memory_tar({
+            f'file_in_tar_in_dir_level_{level}.txt': f'Content of file in tar in dir at level {level}.'
+        })
+
+    if level <= 0:
+        return create_in_memory_tar({
+            'file_1_base.txt': 'Content of file_1 at base level.',
+            'file_2_base.txt': 'Content of file_2 at base level.',
+            'file_3_base.txt': 'Content of file_3 at base level.',
+            'dir_base': {
+                'file_in_dir_base.txt': 'Content in file in base directory.',
+                'tar_in_dir_base.tar': create_tar_with_file('base').getvalue()
+            }
+        })
+
+    nested_tar = create_nested_tar(level - 1)
+
+    if level == 2:
+        gz_content = "This is some content for the gzipped file."
+        gz_file = create_in_memory_gz(gz_content)
+
+        return create_in_memory_tar({
+            f'file_1_level_{level}.txt': f'Content of file_1 at level {level}.',
+            f'file_2_level_{level}.txt': f'Content of file_2 at level {level}.',
+            f'level_{level}_tar.tar': nested_tar.getvalue(),
+            f'dir_level_{level}': {
+                f'file_in_dir_level_{level}.txt': f'Content in file in directory at level {level}.',
+                f'tar_in_dir_level_{level}.tar': create_tar_with_file(level).getvalue(),
+                'sample_file.gz': gz_file.getvalue()
+            }
+        })
+
+    return create_in_memory_tar({
+        f'file_1_level_{level}.txt': f'Content of file_1 at level {level}.',
+        f'file_2_level_{level}.txt': f'Content of file_2 at level {level}.',
+        f'level_{level}_tar.tar': nested_tar.getvalue(),
+        f'dir_level_{level}': {
+            f'file_in_dir_level_{level}.txt': f'Content in file in directory at level {level}.',
+            f'tar_in_dir_level_{level}.tar': create_tar_with_file(level).getvalue()
+        }
+    })
+
+
+def normalize_tree(tree: str) -> str:
+    return tree.replace('|──', '├──')
+
+
+def test_recursive_extraction(tmp_path):
+    """expected tree:
+
+        ├── extracted
+        │   ├── level_3_tar
+        │   │   ├── level_2_tar
+        │   │   │   ├── level_1_tar
+        │   │   │   │   ├── dir_base
+        │   │   │   │   │   ├── tar_in_dir_base
+        │   │   │   │   │   │   ├── file_in_tar_in_dir_level_base.txt
+        │   │   │   │   │   ├── file_in_dir_base.txt
+        │   │   │   │   ├── file_3_base.txt
+        │   │   │   │   ├── file_2_base.txt
+        │   │   │   │   ├── file_1_base.txt
+        │   │   │   ├── dir_level_1
+        │   │   │   │   ├── tar_in_dir_level_1
+        │   │   │   │   │   ├── file_in_tar_in_dir_level_1.txt
+        │   │   │   │   ├── file_in_dir_level_1.txt
+        │   │   │   ├── file_2_level_1.txt
+        │   │   │   ├── file_1_level_1.txt
+        │   │   ├── dir_level_2
+        │   │   │   ├── tar_in_dir_level_2
+        │   │   │   │   ├── file_in_tar_in_dir_level_2.txt
+        │   │   │   ├── sample_file
+        │   │   │   ├── file_in_dir_level_2.txt
+        │   │   ├── file_2_level_2.txt
+        │   │   ├── file_1_level_2.txt
+        │   ├── dir_level_3
+        │   │   ├── tar_in_dir_level_3
+        │   │   │   ├── file_in_tar_in_dir_level_3.txt
+        │   │   ├── file_in_dir_level_3.txt
+        │   ├── file_2_level_3.txt
+        │   ├── file_1_level_3.txt
+    """
+
+    nested_tar_buffer = create_nested_tar(3)
+    nested_tar_path = tmp_path / "nested.tar"
+
+    with open(nested_tar_path, 'wb') as file:
+        file.write(nested_tar_buffer.getvalue())
+
+    target_path: Path = tmp_path / "extracted"
+    LocalNestedArchiveExtractor().recursive_extraction(nested_tar_path, target_path, root_tar_path=nested_tar_path)
+
+    assertions: dict[Path, str] = {
+        target_path / "file_1_level_3.txt": "Content of file_1 at level 3.",  # files in tars
+        target_path / "level_3_tar" / "dir_level_2" / "file_in_dir_level_2.txt": "Content in file in directory at level 2.",  # directories in tars
+        target_path / "level_3_tar" / "level_2_tar" / "dir_level_1" / "tar_in_dir_level_1" / "file_in_tar_in_dir_level_1.txt": "Content of file in tar in dir at level 1.",  # tars in directories in tars
+        target_path / "level_3_tar" / "dir_level_2" / "sample_file": "This is some content for the gzipped file."
+    }
+
+    for file_path, content in assertions.items():
+        assert file_path.read_text() == content

--- a/tools/triage/add_triage_signature.py
+++ b/tools/triage/add_triage_signature.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 from collections import Counter, OrderedDict, defaultdict
 from datetime import datetime
-from itertools import filterfalse
 from textwrap import dedent
 
 import colorlog
@@ -32,7 +31,22 @@ from retry import retry
 from tabulate import tabulate
 
 from tools.jira_client import JiraClientFactory
-from tools.triage.common import JIRA_PROJECT, get_cluster_logs_base_url
+from tools.triage.common import (
+    JIRA_PROJECT,
+    SignaturesSource,
+    get_cluster_logs_base_url,
+    get_metadata_json,
+)
+from tools.triage.exceptions import (
+    FailedToGetLogsTarException,
+    FailedToGetMetadataException,
+)
+from tools.triage.utils.extraction.jira_attachment_querier.jira_remote_archive_querier import (
+    JiraAttachmentsQuerier,
+)
+from tools.triage.utils.extraction.jira_attachment_querier.local_nested_archive_extractor import (
+    LocalNestedArchiveExtractor,
+)
 
 DEFAULT_DAYS_TO_HANDLE = 30
 SUMMARY_PATTERN = r"cloud\.redhat\.com failure: (?P<failure_id>.+)"
@@ -102,57 +116,44 @@ def format_description(failure_data):
     return JIRA_DESCRIPTION.format(**failure_data)
 
 
-class FailedToGetMetadataException(Exception):
-    pass
-
-
-class FailedToGetInstallConfigException(Exception):
-    pass
-
-
-def clean_metadata_json(md):
-    installation_start_time = dateutil.parser.isoparse(md["cluster"]["install_started_at"])
-
-    def host_deleted_before_installation_started(host):
-        if deleted_at := host.get("deleted_at"):
-            return dateutil.parser.isoparse(deleted_at) < installation_start_time
-        return False
-
-    md["cluster"]["deleted_hosts"] = list(filter(host_deleted_before_installation_started, md["cluster"]["hosts"]))
-    md["cluster"]["hosts"] = list(filterfalse(host_deleted_before_installation_started, md["cluster"]["hosts"]))
-
-    return md
-
-
-@functools.lru_cache(maxsize=1000)
-def get_metadata_json(cluster_url):
+def get_manifests(
+    cluster_url: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
+    # the format is: [{"name": ..., "type": ..., "mtime": ..., "size": ...}, ...]
     try:
-        res = requests.get("{}/metadata.json".format(cluster_url))
-        res.raise_for_status()
-        return clean_metadata_json(res.json())
-    except Exception as e:
-        raise FailedToGetMetadataException from e
+        if signatures_source == SignaturesSource.JIRA:
+            jira_querier = JiraAttachmentsQuerier(
+                jira_client=jira_client, issue_key=issue_key, attachment_file_name="cluster_files.tar.gz", logger=logger
+            )
+            return LocalNestedArchiveExtractor().convert_directory_to_json(jira_querier.get("cluster_files/manifests"))
 
-
-def get_manifests(cluster_url):
-    try:
         res = requests.get("{}/cluster_files/manifests".format(cluster_url))
         res.raise_for_status()
-
-        # the format is: [{"name": ..., "type": ..., "mtime": ..., "size": ...}, ...]
         return res.json()
+
     except Exception as e:
         raise FailedToGetMetadataException from e
 
 
 @functools.lru_cache(maxsize=1000)
-def get_installconfig_yaml(cluster_url):
-    try:
-        res = requests.get("{}/cluster_files/install-config.yaml".format(cluster_url))
-        res.raise_for_status()
-        return yaml.safe_load(res._content)
-    except Exception as e:
-        raise FailedToGetInstallConfigException from e
+def get_installconfig_yaml(
+    cluster_url: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
+    if signatures_source == SignaturesSource.JIRA:
+        jira_querier = JiraAttachmentsQuerier(
+            jira_client=jira_client, issue_key=issue_key, attachment_file_name="cluster_files.tar.gz", logger=logger
+        )
+        return yaml.safe_load(jira_querier.get("cluster_files/install-config.yaml", mode="rb"))
+
+    res = requests.get("{}/cluster_files/install-config.yaml".format(cluster_url))
+    res.raise_for_status()
+    return yaml.safe_load(res._content)
 
 
 def partition(iterator, predicate):
@@ -173,32 +174,72 @@ def partition(iterator, predicate):
 
 
 @functools.lru_cache(maxsize=1000)
-def _get_all_cluster_events(logs_url, cluster_id):
+def _get_all_cluster_events(
+    logs_url: str,
+    cluster_id: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
     """
     WARNING - It's likely you do not want to use this function
     as it returns all recorded events for this cluster rather than
     just the events relevant to the latest installation attempt for
     which this ticket was created
     """
+    if signatures_source == SignaturesSource.JIRA:
+        jq = JiraAttachmentsQuerier(
+            jira_client=jira_client,
+            issue_key=issue_key,
+            attachment_file_name=f"cluster_{cluster_id}_events.json",
+            logger=logger,
+        )
+        return json.loads(jq.get(mode="rb"))
+
     res = requests.get(f"{logs_url}/cluster_{cluster_id}_events.json")
     res.raise_for_status()
     return res.json()
 
 
-def _partition_cluster_events(logs_url, cluster_id):
+def _partition_cluster_events(
+    logs_url: str,
+    cluster_id: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
     """
     Use the reset event to partition the events list into separate installations
     """
     return partition(
-        _get_all_cluster_events(logs_url, cluster_id), lambda event: event["name"] == "cluster_installation_reset"
+        _get_all_cluster_events(
+            logs_url=logs_url,
+            cluster_id=cluster_id,
+            jira_client=jira_client,
+            issue_key=issue_key,
+            signatures_source=signatures_source,
+        ),
+        lambda event: event["name"] == "cluster_installation_reset",
     )
 
 
-def get_cluster_installation_events(logs_url, cluster_id):
+def get_cluster_installation_events(
+    logs_url: str,
+    cluster_id: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
     # Use just the last partition, as it contains all the events that apply to
     # this current installation, as the logs for this failure were collected
     # right after this installation failed, before the cluster was reset.
-    return _partition_cluster_events(logs_url, cluster_id)[-1]
+    return _partition_cluster_events(
+        logs_url=logs_url,
+        cluster_id=cluster_id,
+        jira_client=jira_client,
+        issue_key=issue_key,
+        signatures_source=signatures_source,
+    )[-1]
 
 
 @functools.lru_cache(maxsize=100)
@@ -206,22 +247,46 @@ def get_remote_archive(tar_url):
     return nestedarchive.RemoteNestedArchive(tar_url, init_download=True)
 
 
-class FailedToGetLogsTarException(Exception):
-    pass
-
-
-def get_triage_logs_tar(triage_url, cluster_id):
+def get_triage_logs_tar(
+    triage_url: str,
+    cluster_id: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+) -> nestedarchive.RemoteNestedArchive | JiraAttachmentsQuerier:
     try:
+        if signatures_source == SignaturesSource.JIRA:
+            return JiraAttachmentsQuerier(
+                jira_client=jira_client,
+                issue_key=issue_key,
+                attachment_file_name=f"cluster_{cluster_id}_logs.tar",
+                logger=logger,
+            )
+
         tar_url = f"{triage_url}/cluster_{cluster_id}_logs.tar"
         return get_remote_archive(tar_url)
-    except requests.exceptions.HTTPError as e:
+
+    except Exception as e:
         raise FailedToGetLogsTarException from e
 
 
-def get_controller_logs(triage_url):
-    return get_triage_logs_tar(triage_url=triage_url, cluster_id=get_metadata_json(triage_url)["cluster"]["id"]).get(
-        "controller_logs.tar.gz/assisted-installer-controller*.logs"
-    )
+def get_controller_logs(
+    triage_url: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
+    cluster_id = get_metadata_json(
+        cluster_url=triage_url, jira_client=jira_client, issue_key=issue_key, signatures_source=signatures_source
+    )["cluster"]["id"]
+
+    return get_triage_logs_tar(
+        triage_url=triage_url,
+        cluster_id=cluster_id,
+        jira_client=jira_client,
+        issue_key=issue_key,
+        signatures_source=signatures_source,
+    ).get("controller_logs.tar.gz/assisted-installer-controller*.logs")
 
 
 def get_host_log_file(triage_logs_tar, host_id, filename):
@@ -253,9 +318,21 @@ def get_journal(triage_logs_tar, host_ip, journal_file, **kwargs):
         return triage_logs_tar.get(old_logs_path, **kwargs)
 
 
-def get_events_by_host(logs_url, cluster_id):
+def get_events_by_host(
+    logs_url: str,
+    cluster_id: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
     events_by_host = defaultdict(list)
-    for event in get_cluster_installation_events(logs_url, cluster_id):
+    for event in get_cluster_installation_events(
+        logs_url=logs_url,
+        cluster_id=cluster_id,
+        jira_client=jira_client,
+        issue_key=issue_key,
+        signatures_source=signatures_source,
+    ):
         if "host_id" not in event:
             # Cluster-level event, no host_id associated with it
             continue
@@ -267,18 +344,11 @@ def get_event_timestamp(event):
     return dateutil.parser.isoparse(event["event_time"])
 
 
-class FailedToGetMustgatherException(Exception):
-    pass
-
-
 def get_mustgather(triage_logs_tar):
-    try:
-        return triage_logs_tar.get(
-            "controller_logs.tar.gz/must-gather.tar.gz",
-            mode="rb",
-        )
-    except Exception as e:
-        raise FailedToGetMustgatherException from e
+    return triage_logs_tar.get(
+        "controller_logs.tar.gz/must-gather.tar.gz",
+        mode="rb",
+    )
 
 
 ############################
@@ -294,6 +364,7 @@ class Signature(abc.ABC):
         should_reevaluate=False,
         old_comment_string=None,
         pull_secret_file=None,
+        signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
     ):
         self._jira_client: jira.JIRA = jira_client
         self._identifing_string = comment_identifying_string
@@ -302,6 +373,7 @@ class Signature(abc.ABC):
         self.should_reevaluate = should_reevaluate
         self.issue_key = issue_key
         self.pull_secret_file = pull_secret_file
+        self.signatures_source = signatures_source
 
     def process_ticket(self, url, issue_key):
         try:
@@ -310,12 +382,15 @@ class Signature(abc.ABC):
             browse_url = get_ticket_browse_url(issue_key)
             logger.error(f"Error getting metadata for {browse_url} at {url}: {e.__cause__}, it may have been deleted")
         except FailedToGetLogsTarException as e:
-            if e.__cause__.response.status_code == 404:
-                logger.warning(
-                    f"{get_ticket_browse_url(issue_key)} doesn't have a log tar, skipping {type(self).__name__}"
-                )
-                return
-            raise
+            try:
+                if e.__cause__.response.status_code == 404:
+                    logger.warning(
+                        f"{get_ticket_browse_url(issue_key)} doesn't have a log tar, skipping {type(self).__name__}"
+                    )
+                    return
+                raise
+            except Exception:
+                raise e
         except Exception:
             logger.exception("error updating ticket %s", issue_key)
 
@@ -520,7 +595,12 @@ class OpenShiftVersionSignature(Signature):
         super().__init__(*args, **kwargs, comment_identifying_string="")
 
     def _process_ticket(self, url, issue_key):
-        metadata = get_metadata_json(url)
+        metadata = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         major, minor, *_ = metadata["cluster"]["openshift_version"].split(".")
         ticket_affected_version_field = f"OpenShift {major}.{minor}"
 
@@ -537,11 +617,21 @@ class HostsStatusSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         try:
-            installconfig = get_installconfig_yaml(url)
-        except FailedToGetInstallConfigException:
+            installconfig = get_installconfig_yaml(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+        except Exception:
             logger.exception("Failed to get install-config.yaml")
             self._update_triaging_ticket(
                 "Installation status signature cannot be created. This cluster's collected logs are missing install-config.yaml for an unknown reason, why is it missing?"
@@ -596,7 +686,12 @@ class DeletedHostsStatusSignature(Signature):
         super().__init__(*args, **kwargs, comment_identifying_string="h1. Deleted hosts status")
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         if len(md["cluster"]["deleted_hosts"]) < 1:
             return
@@ -694,7 +789,12 @@ class FailureDescription(Signature):
         return format_description(cluster_data)
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -745,7 +845,12 @@ class FailureDetails(Signature):
         issue = self._jira_client.issue(issue_key)
         cluster_md = []
         try:
-            md = get_metadata_json(url)
+            md = get_metadata_json(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
             cluster_md = md["cluster"]
         except Exception:
             # if we cannot find the failure logs on the log-server, we'll just use whatever information we
@@ -804,7 +909,12 @@ class HostsExtraDetailSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -844,7 +954,12 @@ class MasterFailedToPullIgnitionSignature(ErrorSignature):
 
     def _process_ticket(self, url, issue_key):
         hosts = []
-        cluster_hosts = get_metadata_json(url)["cluster"]["hosts"]
+        cluster_hosts = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]["hosts"]
         # this signature is not relevant for SNO
         if len(cluster_hosts) <= 1:
             return
@@ -902,12 +1017,23 @@ class InstallationDiskFIOSignature(Signature):
         return ((event, get_duration(event)) for event in events if get_duration(event) is not None)
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
         cluster_id = cluster["id"]
-        events = get_cluster_installation_events(url, cluster_id)
+        events = get_cluster_installation_events(
+            logs_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         fio_events = self._get_fio_events(events)
 
         fio_events_by_host = defaultdict(list)
@@ -963,12 +1089,23 @@ class SlowImageDownload(ErrorSignature):
         return [image_info for event in events if (image_info := get_image_download_info(event)) is not None]
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
         cluster_id = cluster["id"]
-        events = get_cluster_installation_events(url, cluster_id)
+        events = get_cluster_installation_events(
+            logs_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         image_info_list = self._list_image_download_info(events)
 
         abnormal_image_info = []
@@ -1008,12 +1145,23 @@ class PendingUserAction(ErrorSignature):
         return [status for event in events if (status := get_cluster_status(event)) is not None]
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
         cluster_id = cluster["id"]
-        events = get_cluster_installation_events(url, cluster_id)
+        events = get_cluster_installation_events(
+            logs_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster_status_list = self._list_cluster_status_updates(events)
         # This is signing triage tickets where the last status is always "error"
         if len(cluster_status_list) >= 2 and cluster_status_list[-2] == "installing-pending-user-action":
@@ -1034,7 +1182,12 @@ class StorageDetailSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -1073,7 +1226,12 @@ class SNOMachineCidrSignature(Signature):
         super().__init__(*args, **kwargs, comment_identifying_string="h1. Invalid machine cidr")
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -1111,7 +1269,12 @@ class ComponentsVersionSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         report = ""
         release_tag = md.get("release_tag")
@@ -1141,7 +1304,12 @@ class LibvirtRebootFlagSignature(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -1192,7 +1360,13 @@ class ApiInvalidCertificateSignature(ErrorSignature):
 
     def _process_ticket(self, url, issue_key):
         try:
-            controller_logs = get_controller_logs(url)
+            controller_logs = get_controller_logs(
+                triage_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+
         except FileNotFoundError:
             return
 
@@ -1223,10 +1397,21 @@ class NameserverInClusterNetwork(ErrorSignature):
             comment_identifying_string="h1. Nameserver in internal network",
         )
 
-    def _get_resolv_conf_files(self, url, base_path):
+    def _get_resolv_conf_files(self, url, base_path, issue_key: str):
         files = []
         try:
-            triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"])
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
         except FileNotFoundError:
             return files
 
@@ -1253,9 +1438,9 @@ class NameserverInClusterNetwork(ErrorSignature):
         network = ipaddress.ip_network(cidr_str, strict=False)
         return ip_address in network
 
-    def _get_nameservers(self, url, base_path):
+    def _get_nameservers(self, url, base_path, issue_key: str):
         nameservers = set()
-        for resolvconf in self._get_resolv_conf_files(url, base_path):
+        for resolvconf in self._get_resolv_conf_files(url, base_path, issue_key=issue_key):
             for line in resolvconf.splitlines():
                 match = re.search(self.NAMESERVER_PATTERN, line)
                 if match:
@@ -1264,11 +1449,16 @@ class NameserverInClusterNetwork(ErrorSignature):
         return nameservers
 
     def _process_ticket_helper(self, path, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cidrs = [network["cidr"] for network in md["cluster"]["cluster_networks"]]
 
         report = ""
-        for nameserver in self._get_nameservers(url, path):
+        for nameserver in self._get_nameservers(url, path, issue_key=issue_key):
             for cidr in cidrs:
                 if self._check_ip_in_cidr(nameserver, cidr):
                     report += f"user defined nameserver {nameserver} which overlaps with the cluster nw {cidr}\n"
@@ -1299,13 +1489,25 @@ class ApiExpiredCertificateSignature(ErrorSignature):
             comment_identifying_string="h1. Expired Certificate",
         )
 
-    def _process_ticket_helper(self, url, path):
+    def _process_ticket_helper(self, url, path, issue_key: str):
         try:
-            bootstrap_kube_apiserver_logs = get_triage_logs_tar(
-                triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]
-            ).get(path)
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+            bootstrap_kube_apiserver_logs = triage_logs_tar.get(path)
+
         except FileNotFoundError:
             return
+
         if invalid_api_log_lines := self.LOG_PATTERN.findall(bootstrap_kube_apiserver_logs):
             report = f"{{code}}{invalid_api_log_lines[0]}{{code}}"
             if (num_lines := len(invalid_api_log_lines)) > 1:
@@ -1316,11 +1518,11 @@ class ApiExpiredCertificateSignature(ErrorSignature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/bootstrap/containers/bootstrap-control-plane/kube-apiserver.log"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/bootstrap/containers/bootstrap-control-plane/kube-apiserver.log"
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            self._process_ticket_helper(url, old_logs_path)
+            self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
 
 
 class AllInstallationAttemptsSignature(Signature):
@@ -1332,7 +1534,12 @@ class AllInstallationAttemptsSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster = md["cluster"]
         cluster_id = cluster["id"]
         cluster_triage_tickets = self._jira_client.search_issues(
@@ -1363,7 +1570,12 @@ class MediaDisconnectionSignature(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster = md["cluster"]
 
         hosts = list()
@@ -1406,7 +1618,12 @@ class CoreOSInstallerErrorSignature(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster = md["cluster"]
 
         hosts = list()
@@ -1467,12 +1684,23 @@ class IpChangedAfterReboot(ErrorSignature):
         return address_map
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
         cluster_id = cluster["id"]
 
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         for host in cluster["hosts"]:
             host_id = host["id"]
@@ -1562,12 +1790,23 @@ class AgentStepFailureSignature(Signature):
         return "".join(output_lines)
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
         cluster_id = cluster["id"]
 
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         report = ""
         for host in cluster["hosts"]:
@@ -1629,7 +1868,12 @@ class MissingMustGatherLogs(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster_hosts = md["cluster"]["hosts"]
         bootstrap_node = [host for host in cluster_hosts if host["bootstrap"]][0]
 
@@ -1643,10 +1887,16 @@ class MissingMustGatherLogs(ErrorSignature):
 
         if md["cluster"]["logs_info"] in ("timeout", "completed"):
             cluster_id = md["cluster"]["id"]
-            triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=cluster_id,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
             try:
                 get_mustgather(triage_logs_tar)
-            except FailedToGetMustgatherException:
+            except Exception:
                 self._update_triaging_ticket(
                     "This cluster's collected logs are missing must-gather logs although it should be collected, why is it missing?"
                 )
@@ -1670,13 +1920,24 @@ class MustGatherAnalysis(Signature):
                 logger.debug("must-gather analysis already exists as attachment %s", attachment.filename)
                 return
 
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster_id = md["cluster"]["id"]
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         try:
             mustgather = get_mustgather(triage_logs_tar)
-        except FailedToGetMustgatherException:
+        except Exception:
             return
 
         with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp_mustgather:
@@ -1792,8 +2053,19 @@ class OSInstallationTime(Signature):
         return entry
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
-        events_by_host = get_events_by_host(url, cluster["id"])
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
+        events_by_host = get_events_by_host(
+            logs_url=url,
+            cluster_id=cluster["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         host_entries = [self.host_entry(host, events_by_host[host["id"]]) for host in cluster["hosts"]]
 
         # Only report if we have at least one slow host
@@ -1820,7 +2092,12 @@ class NonstandardNetworkType(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        install_config = get_installconfig_yaml(url)
+        install_config = get_installconfig_yaml(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         network_type = install_config["networking"]["networkType"]
 
         if network_type not in self.allowed_network_types:
@@ -1844,7 +2121,18 @@ class FlappingValidations(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        events = get_events_by_host(url, get_metadata_json(url)["cluster"]["id"])
+        events = get_events_by_host(
+            logs_url=url,
+            cluster_id=get_metadata_json(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )["cluster"]["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         host_tables = {}
         for host, events in events.items():
@@ -1896,7 +2184,12 @@ class WrongBootOrderSignature(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
         status_info = cluster["status_info"]
@@ -1906,7 +2199,13 @@ class WrongBootOrderSignature(ErrorSignature):
 
         cluster_id = cluster["id"]
         report = ""
-        events = get_cluster_installation_events(url, cluster_id)
+        events = get_cluster_installation_events(
+            logs_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         reboot_events_by_host = defaultdict(list)
         for event in events:
             if self.EVENT_PATTERN in event["message"]:
@@ -1951,12 +2250,23 @@ class ReleasePullErrorSignature(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
         cluster_id = cluster["id"]
 
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         report = ""
         for host in cluster["hosts"]:
@@ -1993,15 +2303,34 @@ class EventsInstallationAttempts(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
         cluster_id = cluster["id"]
 
-        installation_attempts = len(_partition_cluster_events(url, cluster_id))
+        installation_attempts = len(
+            _partition_cluster_events(
+                logs_url=url,
+                cluster_id=cluster_id,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+        )
 
         if installation_attempts != 1:
-            last_attempt_first_event = get_cluster_installation_events(url, cluster_id)[0]
+            last_attempt_first_event = get_cluster_installation_events(
+                logs_url=url,
+                cluster_id=cluster_id,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )[0]
             self._update_triaging_ticket(
                 dedent(
                     f"""
@@ -2034,7 +2363,13 @@ class ControllerOperatorStatus(Signature):
                 return
 
         try:
-            controller_logs = get_controller_logs(url)
+            controller_logs = get_controller_logs(
+                triage_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+
         except FileNotFoundError:
             return
 
@@ -2090,11 +2425,22 @@ class DualStackBadRoute(ErrorSignature):
             function_impact_label="bz2088346",
         )
 
-    def _process_ticket_helper(self, url, path):
+    def _process_ticket_helper(self, url, path, issue_key: str):
         try:
-            ovnkube_logs = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]).get(
-                path
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
             )
+            ovnkube_logs = triage_logs_tar.get(path)
+
         except FileNotFoundError:
             return
 
@@ -2111,11 +2457,11 @@ class DualStackBadRoute(ErrorSignature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/control-plane/*/containers/ovnkube-node-*.log"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/control-plane/*/containers/ovnkube-node-*.log"
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            self._process_ticket_helper(url, old_logs_path)
+            self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
 
 
 class StaticNetworking(Signature):
@@ -2141,7 +2487,12 @@ class StaticNetworking(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        infraenvs = get_metadata_json(url).get("infraenvs", [])
+        infraenvs = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        ).get("infraenvs", [])
         messages = [
             f"""Infraenv {infraenv["name"]} has static network config:
 {{code}}
@@ -2178,11 +2529,20 @@ class NodeStatus(Signature):
 
         return f"Status {condition['status']} with reason {condition['reason']}, message {condition['message']}"
 
-    def _process_ticket_helper(self, url, path):
+    def _process_ticket_helper(self, url, path, issue_key: str):
         try:
-            nodes_json = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]).get(
-                path
-            )
+            nodes_json = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            ).get(path)
         except FileNotFoundError:
             return
 
@@ -2215,11 +2575,11 @@ class NodeStatus(Signature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/resources/nodes.json"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/resources/nodes.json"
         try:
-            report = self._process_ticket_helper(url, new_logs_path)
+            report = self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            return self._process_ticket_helper(url, old_logs_path)
+            return self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
         return report
 
 
@@ -2232,7 +2592,12 @@ class HostsInterfacesSignature(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         cluster = md["cluster"]
 
@@ -2283,11 +2648,25 @@ class NetworksMtuMismatch(ErrorSignature):
 
     def _process_ticket(self, url, issue_key):
         try:
-            sdn_logs = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]).get(
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+            sdn_logs = triage_logs_tar.get(
                 "controller_logs.tar.gz/must-gather.tar.gz/must-gather.local.*/*/namespaces/openshift-sdn/pods/sdn-*/sdn/sdn/logs/*.log"
             )
+
         except FileNotFoundError:
             return
+
         if match := self.LOG_PATTERN.search(sdn_logs):
             self._update_triaging_ticket(
                 "SDN failed to start: Overlay (cluster) network MTU {}"
@@ -2336,9 +2715,22 @@ class ErrorCreatingReadWriteLayer(ErrorSignature):
 
     def _process_ticket(self, url, issue_key):
         try:
-            must_gather_namespaces_dir = get_triage_logs_tar(
-                triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]
-            ).get("controller_logs.tar.gz/must-gather.tar.gz/must-gather.local.*/*/namespaces")
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+
+            must_gather_namespaces_dir = triage_logs_tar.get(
+                "controller_logs.tar.gz/must-gather.tar.gz/must-gather.local.*/*/namespaces"
+            )
         except FileNotFoundError:
             return
 
@@ -2359,11 +2751,23 @@ class DualstackrDNSBug(ErrorSignature):
             function_impact_label="mgmt11651",
         )
 
-    def _process_ticket_helper(self, url, path):
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"])
+    def _process_ticket_helper(self, url, path, issue_key: str):
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=get_metadata_json(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )["cluster"]["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         try:
             kubeapiserver_logs = triage_logs_tar.get(path)
+
         except FileNotFoundError:
             return
 
@@ -2376,11 +2780,11 @@ class DualstackrDNSBug(ErrorSignature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/bootstrap/containers/kube-apiserver-*.log"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/bootstrap/containers/kube-apiserver-*.log"
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            self._process_ticket_helper(url, old_logs_path)
+            self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
 
 
 class InsufficientLVMCleanup(ErrorSignature):
@@ -2393,7 +2797,12 @@ class InsufficientLVMCleanup(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
 
         host_messages = [
             f"Host {self._get_hostname(host)} has LVM disks and has the 'Can't open' coreos-installer error, this is probably due to MGMT-11695"
@@ -2425,8 +2834,19 @@ class ErrorOnCleanupInstallDevice(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster["id"])
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         hosts = []
         for host in cluster["hosts"]:
@@ -2463,7 +2883,12 @@ class UserManagedNetworkingLoadBalancer(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        md = get_metadata_json(url)
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         cluster_md = md["cluster"]
         if not cluster_md.get("user_managed_networking", False):
             return
@@ -2472,7 +2897,13 @@ class UserManagedNetworkingLoadBalancer(ErrorSignature):
             return
 
         try:
-            controller_logs = get_controller_logs(url)
+            controller_logs = get_controller_logs(
+                triage_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+
         except FileNotFoundError:
             return
 
@@ -2503,7 +2934,16 @@ class TagAnalysis(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        tags = set(get_metadata_json(url)["cluster"].get("tags", "").split(","))
+        tags = set(
+            get_metadata_json(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )["cluster"]
+            .get("tags", "")
+            .split(",")
+        )
 
         if tags == {""}:
             return
@@ -2539,7 +2979,12 @@ class SkipDisks(ErrorSignature):
     def _process_ticket(self, url, issue_key):
         skip_disks = {
             host["id"]: host["skip_formatting_disks"].split(",")
-            for host in get_metadata_json(url)["cluster"].get("hosts", [])
+            for host in get_metadata_json(
+                cluster_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )["cluster"].get("hosts", [])
             if host.get("skip_formatting_disks", None) is not None and host["skip_formatting_disks"] != ""
         }
 
@@ -2575,8 +3020,19 @@ class FailedRequestTriggersHostTimeout(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster["id"])
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         failed_requests_hosts = self._failed_requests_hosts(cluster, triage_logs_tar)
         timed_out_hosts = self._timed_out_hosts(cluster)
@@ -2624,7 +3080,12 @@ class ControllerWarnings(Signature):
 
     def _process_ticket(self, url, issue_key):
         try:
-            controller_logs = get_controller_logs(url)
+            controller_logs = get_controller_logs(
+                triage_url=url,
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
         except FileNotFoundError:
             logger.info("Skipping ControllerWarnings signature because no controller logs")
             return
@@ -2655,10 +3116,21 @@ class UserHasLoggedIntoCluster(Signature):
         )
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
         cluster_id = cluster["id"]
 
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster_id)
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster_id,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         report = ""
         for host in cluster["hosts"]:
@@ -2739,9 +3211,20 @@ class OSTreeCommitMismatch(ErrorSignature):
             release_data = commitid
         return status == release_data
 
-    def _process_ticket_helper(self, url, path):
-        md = get_metadata_json(url)
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=md["cluster"]["id"])
+    def _process_ticket_helper(self, url, path, issue_key: str):
+        md = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=md["cluster"]["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         if not (os_content_image := self.get_os_content_image(md["cluster"]["ocp_release_image"])):
             self._update_triaging_ticket(
@@ -2805,12 +3288,12 @@ class OSTreeCommitMismatch(ErrorSignature):
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/control-plane"
 
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             try:
                 logger.debug("Searching logs under the old location %s", old_logs_path)
-                self._process_ticket_helper(url, old_logs_path)
+                self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
             except FileNotFoundError:
                 logger.debug("no logs-bundle available")
                 return
@@ -2829,14 +3312,25 @@ class ControllerFailedToStart(ErrorSignature):
             comment_identifying_string="h1. Assisted Installer Controller failed to start",
         )
 
-    def _process_ticket_helper(self, url, path):
-        cluster = get_metadata_json(url)["cluster"]
+    def _process_ticket_helper(self, url, path, issue_key: str):
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
         bootstrap_node = [host for host in cluster["hosts"] if host["bootstrap"]][0]
 
         if bootstrap_node["progress"]["current_stage"] != "Waiting for controller":
             return
 
-        triage_logs_tar = get_triage_logs_tar(triage_url=url, cluster_id=cluster["id"])
+        triage_logs_tar = get_triage_logs_tar(
+            triage_url=url,
+            cluster_id=cluster["id"],
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
         try:
             # Fetch pods.json from the bootstrap log bundle
             pods_json = triage_logs_tar.get(path)
@@ -2885,11 +3379,11 @@ class ControllerFailedToStart(ErrorSignature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/resources/pods.json"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/resources/pods.json"
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            self._process_ticket_helper(url, old_logs_path)
+            self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
 
 
 class MachineConfigDaemonErrorExtracting(ErrorSignature):
@@ -2906,9 +3400,22 @@ class MachineConfigDaemonErrorExtracting(ErrorSignature):
             comment_identifying_string="h1. machine-config-daemon could not extract machine-os-content",
         )
 
-    def _process_ticket_helper(self, url, path):
+    def _process_ticket_helper(self, url, path, issue_key: str):
         try:
-            mcd_logs = get_triage_logs_tar(triage_url=url, cluster_id=get_metadata_json(url)["cluster"]["id"]).get(path)
+            triage_logs_tar = get_triage_logs_tar(
+                triage_url=url,
+                cluster_id=get_metadata_json(
+                    cluster_url=url,
+                    jira_client=self._jira_client,
+                    issue_key=issue_key,
+                    signatures_source=self.signatures_source,
+                )["cluster"]["id"],
+                jira_client=self._jira_client,
+                issue_key=issue_key,
+                signatures_source=self.signatures_source,
+            )
+            mcd_logs = triage_logs_tar.get(path)
+
         except FileNotFoundError:
             return
 
@@ -2925,11 +3432,11 @@ class MachineConfigDaemonErrorExtracting(ErrorSignature):
         new_logs_path = f"{NEW_LOG_BUNDLE_PATH}/control-plane/*/journals/machine-config-daemon-firstboot.log"
         old_logs_path = f"{OLD_LOG_BUNDLE_PATH}/control-plane/*/journals/machine-config-daemon-firstboot.log"
         try:
-            self._process_ticket_helper(url, new_logs_path)
+            self._process_ticket_helper(url, new_logs_path, issue_key=issue_key)
             logger.debug("Found logs under the new location %s", new_logs_path)
         except FileNotFoundError:
             logger.debug("Searching logs under the old location %s", old_logs_path)
-            self._process_ticket_helper(url, old_logs_path)
+            self._process_ticket_helper(url, old_logs_path, issue_key=issue_key)
 
 
 class SNOHostnameHasEtcd(ErrorSignature):
@@ -2946,7 +3453,12 @@ class SNOHostnameHasEtcd(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        cluster = get_metadata_json(url)["cluster"]
+        cluster = get_metadata_json(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )["cluster"]
 
         if cluster.get("high_availability_mode") != "None":
             return
@@ -2975,7 +3487,12 @@ class EmptyManifest(ErrorSignature):
         )
 
     def _process_ticket(self, url, issue_key):
-        manifests = get_manifests(url)
+        manifests = get_manifests(
+            cluster_url=url,
+            jira_client=self._jira_client,
+            issue_key=issue_key,
+            signatures_source=self.signatures_source,
+        )
 
         # Sometimes manifest have "empty" junk like spaces or "---", so if it's
         # less than 30 bytes, it's probably "empty"
@@ -3177,6 +3694,7 @@ def process_issues(
     only_specific_signatures,
     dry_run_file,
     pull_secret_file=None,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
 ):
     logger.info(f"Found {len(issues)} tickets, processing...")
 
@@ -3205,6 +3723,7 @@ def process_issues(
             only_specific_signatures=only_specific_signatures,
             dry_run_file=dry_run_file,
             pull_secret_file=pull_secret_file,
+            signatures_source=signatures_source,
         )
 
         # Hacky solution to prevent tqdm from writing over the last line of the signature
@@ -3219,6 +3738,7 @@ def main(args):
     )
 
     pull_secret_file = args.pull_secret_file
+    signatures_source = SignaturesSource(args.signatures_source)
 
     if args.pull_secret_contents:
         pull_secret_tmp_file = tempfile.NamedTemporaryFile(mode="w")
@@ -3244,6 +3764,7 @@ def main(args):
                 only_specific_signatures=args.update_signature,
                 dry_run_file=dry_run_file,
                 pull_secret_file=pull_secret_file,
+                signatures_source=signatures_source,
             )
             logger.info(f"Dry run output written to {dry_run_file.name}")
         return
@@ -3255,6 +3776,7 @@ def main(args):
         only_specific_signatures=args.update_signature,
         dry_run_file=sys.stdout if args.dry_run else None,
         pull_secret_file=pull_secret_file,
+        signatures_source=signatures_source,
     )
 
 
@@ -3271,6 +3793,7 @@ def process_ticket_with_signatures(
     dry_run_file,
     pull_secret_file=None,
     should_reevaluate=False,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
 ):
     signatures = (
         ALL_SIGNATURES
@@ -3291,6 +3814,7 @@ def process_ticket_with_signatures(
             should_reevaluate=True if only_specific_signatures is not None else should_reevaluate,
             issue_key=issue_key,
             dry_run_file=dry_run_file,
+            signatures_source=signatures_source,
         ).process_ticket(
             ticket_logs_url,
             issue_key,
@@ -3335,9 +3859,14 @@ def parse_args():
         "--pull-secret-contents",
         default=os.environ.get("PULL_SECRET_CONTENTS"),
         required=False,
-        help="pull secret acutal file contents",
+        help="The source of the data used to generate the signatures",
     )
-
+    parser.add_argument(
+        "--signatures-source",
+        default=os.environ.get("SIGNATURES_SOURCE", SignaturesSource.LOGS_SERVER.value),
+        required=False,
+        help="Signatures will get created from the specified data source",
+    )
     selectors_group = parser.add_argument_group(title="Issues selection")
     selectors = selectors_group.add_mutually_exclusive_group(required=True)
     selectors.add_argument(
@@ -3387,13 +3916,6 @@ def parse_args():
         action="store_true",
         help=dry_run_msg.format("stdout"),
     )
-    dry_run_args.add_argument(
-        "-t",
-        "--dry-run-temp",
-        action="store_true",
-        help=dry_run_msg.format("a temp file"),
-    )
-
     parser.add_argument(
         "-us",
         "--update-signature",

--- a/tools/triage/clean_old_issues.py
+++ b/tools/triage/clean_old_issues.py
@@ -1,14 +1,13 @@
 import argparse
 import logging
 import os
-from typing import Callable, Final
+from typing import Final
 
 import jira
-from retry import retry
 
 from tools.jira_client import JiraClientFactory
 from tools.jira_client.consts import CLOSED_STATUS
-from tools.triage.common import JIRA_PROJECT
+from tools.triage.common import JIRA_PROJECT, apply_function_with_retry
 
 LOG_LEVEL_DEFAULT: Final[str] = "INFO"
 ISSUES_LIMIT_DEFAULT: Final[int] = 50
@@ -119,11 +118,6 @@ def update_issues(jira_client: jira.JIRA, issues: list[jira.Issue], logger: logg
         for error in errors:
             logger.exception("Error while updating issue in Jira.", exc_info=error)
         raise ExceptionGroup("Failed to update all issues.", errors)
-
-
-@retry(exceptions=jira.JIRAError, tries=3, delay=1)
-def apply_function_with_retry(function: Callable, *args, **kwargs):
-    return function(*args, **kwargs)
 
 
 def main():

--- a/tools/triage/common.py
+++ b/tools/triage/common.py
@@ -1,13 +1,30 @@
+import functools
+import json
 import logging
+from enum import Enum
+from itertools import filterfalse
+from typing import Callable
 
+import dateutil.parser
 import jira
+import requests
 from retry import retry
+
+from tools.triage.exceptions import FailedToGetMetadataException
+from tools.triage.utils.extraction.jira_attachment_querier.jira_remote_archive_querier import (
+    JiraAttachmentsQuerier,
+)
 
 JIRA_PROJECT = "AITRIAGE"
 JIRA_SUMMARY = "cloud.redhat.com failure: {failure_id}"
 LOGS_COLLECTOR = "http://assisted-logs-collector.usersys.redhat.com"
 
 logger = logging.getLogger(__name__)
+
+
+class SignaturesSource(Enum):
+    LOGS_SERVER = "logs_server"
+    JIRA = "jira"
 
 
 @retry(exceptions=jira.exceptions.JIRAError, tries=3, delay=10, logger=logger)
@@ -39,3 +56,44 @@ def get_or_create_triage_ticket(jira_client: jira.JIRA, failure_id: str) -> jira
 
 def get_cluster_logs_base_url(failure_id: str) -> str:
     return f"{LOGS_COLLECTOR}/files/{failure_id}"
+
+
+def clean_metadata_json(md):
+    installation_start_time = dateutil.parser.isoparse(md["cluster"]["install_started_at"])
+
+    def host_deleted_before_installation_started(host):
+        if deleted_at := host.get("deleted_at"):
+            return dateutil.parser.isoparse(deleted_at) < installation_start_time
+        return False
+
+    md["cluster"]["deleted_hosts"] = list(filter(host_deleted_before_installation_started, md["cluster"]["hosts"]))
+    md["cluster"]["hosts"] = list(filterfalse(host_deleted_before_installation_started, md["cluster"]["hosts"]))
+
+    return md
+
+
+@functools.lru_cache(maxsize=1000)
+def get_metadata_json(
+    cluster_url: str,
+    jira_client: jira.JIRA,
+    issue_key: str,
+    signatures_source: SignaturesSource = SignaturesSource.LOGS_SERVER,
+):
+    try:
+        if signatures_source == SignaturesSource.JIRA:
+            jira_querier = JiraAttachmentsQuerier(
+                jira_client=jira_client, issue_key=issue_key, attachment_file_name="metadata.json", logger=logger
+            )
+            return clean_metadata_json(json.loads(jira_querier.get(mode="rb")))
+
+        res = requests.get("{}/metadata.json".format(cluster_url))
+        res.raise_for_status()
+        return clean_metadata_json(res.json())
+
+    except Exception as e:
+        raise FailedToGetMetadataException from e
+
+
+@retry(exceptions=jira.JIRAError, tries=3, delay=1)
+def apply_function_with_retry(function: Callable, *args, **kwargs):
+    return function(*args, **kwargs)

--- a/tools/triage/create_triage_tickets.py
+++ b/tools/triage/create_triage_tickets.py
@@ -6,6 +6,7 @@ For each cluster, which does not already has a triaging Jira ticket, it creates 
 import argparse
 import logging
 import os
+import sys
 import tempfile
 
 import jira
@@ -21,8 +22,12 @@ from tools.triage.add_triage_signature import (
     process_ticket_with_signatures,
 )
 from tools.triage.common import (
+    JIRA_PROJECT,
     LOGS_COLLECTOR,
+    SignaturesSource,
+    apply_function_with_retry,
     get_cluster_logs_base_url,
+    get_metadata_json,
     get_or_create_triage_ticket,
 )
 from tools.utils import days_ago
@@ -53,27 +58,39 @@ def main(args):
         pull_secret_tmp_file.write(args.pull_secret_contents)
         pull_secret_tmp_file.flush()
 
-    res = requests.get("{}/files/".format(LOGS_COLLECTOR))
-    res.raise_for_status()
-    failed_clusters = res.json()
+    signatures_source = SignaturesSource(args.signatures_source)
+
+    if signatures_source == SignaturesSource.JIRA:
+        failed_clusters = apply_function_with_retry(
+            jira_client.search_issues, f"project = {JIRA_PROJECT} AND created >= -{DEFAULT_DAYS_TO_HANDLE}d"
+        )
+
+    else:
+        res = requests.get("{}/files/".format(LOGS_COLLECTOR))
+        res.raise_for_status()
+        failed_clusters = res.json()
 
     for failure in failed_clusters:
-        date = failure["name"].split("_")[0]
+        failure_name = (
+            failure.fields.summary.split()[2] if signatures_source == SignaturesSource.JIRA else failure["name"]
+        )
+        date = failure_name.split("_")[0]
         days_ago_creation = days_ago(date)
 
         if not args.all and days_ago_creation > DEFAULT_DAYS_TO_HANDLE:
             continue
 
-        logs_url = get_cluster_logs_base_url(failure["name"])
+        logs_url = get_cluster_logs_base_url(failure_name)
+        issue_key = failure.key if signatures_source == SignaturesSource.JIRA else ""
 
-        res = requests.get(f"{logs_url}/metadata.json")
-        res.raise_for_status()
-        cluster = res.json()["cluster"]
+        metadata = get_metadata_json(
+            cluster_url=logs_url, jira_client=jira_client, issue_key=issue_key, signatures_source=signatures_source
+        )
 
-        if cluster["status"] != "error":
+        if metadata["cluster"]["status"] != "error":
             continue
 
-        issue = get_or_create_triage_ticket(jira_client, failure["name"])
+        issue = get_or_create_triage_ticket(jira_client, failure_name)
 
         if issue.fields.status.name == "Closed":
             logger.debug("Skipping closed issue %s", issue.key)
@@ -84,13 +101,15 @@ def main(args):
             continue
 
         logger.debug("Processing issue %s", issue.key)
+
         process_ticket_with_signatures(
             jira_client,
             logs_url,
             issue.key,
             only_specific_signatures=None,
-            dry_run_file=None,
+            dry_run_file=sys.stdout if args.dry_run else None,
             pull_secret_file=pull_secret_file,
+            signatures_source=signatures_source,
         )
 
         close_custom_domain_user_ticket(jira_client, issue.key)
@@ -122,7 +141,6 @@ if __name__ == "__main__":
         required=False,
         help="pull secret acutal file contents",
     )
-
     parser.add_argument(
         "-a",
         "--all",
@@ -136,6 +154,19 @@ if __name__ == "__main__":
         "the rules in a given json file which has the format: "
         "{signature_type: {root_issue: message}}",
         default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "triage_resolving_filters.json"),
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="If true, Jira issues will be generated; otherwise, the anticipated issues will be displayed on stdout",
+    )
+    parser.add_argument(
+        "--signatures-source",
+        default=os.environ.get("SIGNATURES_SOURCE", SignaturesSource.LOGS_SERVER.value),
+        required=False,
+        help="Signatures will get created from the specified data source",
+        choices=[source.value for source in SignaturesSource],
     )
     args = parser.parse_args()
 

--- a/tools/triage/exceptions.py
+++ b/tools/triage/exceptions.py
@@ -1,0 +1,6 @@
+class FailedToGetMetadataException(Exception):
+    pass
+
+
+class FailedToGetLogsTarException(Exception):
+    pass

--- a/tools/triage/utils/extraction/jira_attachment_querier/jira_remote_archive_querier.py
+++ b/tools/triage/utils/extraction/jira_attachment_querier/jira_remote_archive_querier.py
@@ -1,0 +1,202 @@
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional, final
+
+import jira
+import nestedarchive
+from retry import retry
+
+from tools.triage.utils.extraction.jira_attachment_querier.local_nested_archive_extractor import (
+    LocalNestedArchiveExtractor,
+)
+
+
+@final
+class JiraAttachmentsQuerier:
+    """Handles querying and extracting attachment from Jira issue."""
+
+    def __init__(
+        self,
+        jira_client: jira.JIRA,
+        issue_key: str,
+        attachment_file_name: str,
+        logger: logging.Logger,
+        extract_tar: bool = False,
+        local_nested_archive_extractor: LocalNestedArchiveExtractor = LocalNestedArchiveExtractor(),
+    ) -> None:
+        """Initializes the JiraAttachmentsQuerier.
+
+        Args:
+            jira_client: Jira client instance.
+            issue_key: Key of the Jira issue.
+            attachment_file_name: Name of the attachment file.
+            logger: Logger instance.
+            extract_tar: Whether to extract the tar attachment (in case it is a tar attachment). Default is False.
+            local_nested_archive_extractor: Instance for extracting local nested archives.
+        """
+        self._jira_client = jira_client
+        self._local_nested_archive_extractor = local_nested_archive_extractor
+        self._logger = logger
+        self._temporary_download_directory_path = Path(tempfile.mkdtemp())
+        self._extract_tar = extract_tar
+        self.extracted = False
+
+        try:
+            self._archive_path = self._get_attachment_from_issue(
+                issue_key=issue_key,
+                attachment_file_name=attachment_file_name,
+                target_directory=self._temporary_download_directory_path,
+            )
+
+        except jira.JIRAError:
+            raise FileNotFoundError
+
+        self.downloaded = True
+
+        # if it is not a tar file, nothing to extract
+        if not self._local_nested_archive_extractor.is_tar_file(Path(attachment_file_name)):
+            self._is_tar_file = False
+            return
+
+        self._is_tar_file = True
+
+        if not extract_tar:
+            return
+
+        # extracting the tar
+        self.temporary_extracted_archive_path = Path(tempfile.mkdtemp())
+        extraction_path = (
+            self.temporary_extracted_archive_path
+            / self._local_nested_archive_extractor.remove_tar_and_gzip_extensions_if_any(attachment_file_name)
+        )
+
+        self._local_nested_archive_extractor.recursive_extraction(
+            source=self._archive_path, target=extraction_path, root_tar_path=self._archive_path
+        )
+        self.extracted = True
+
+    def __del__(self):
+        """Destructor. Removes the temporary directories."""
+        try:
+            shutil.rmtree(self._temporary_download_directory_path)
+
+        except AttributeError:
+            pass
+
+        try:
+            shutil.rmtree(self.temporary_extracted_archive_path)
+
+        except AttributeError:
+            pass
+
+    @staticmethod
+    def _download_attachment(attachment, target_directory: Path) -> Path:
+        """Downloads a given attachment to the specified directory.
+
+        Args:
+            attachment: The attachment object to download.
+            target_directory (Path): The directory where the attachment should be saved.
+
+        Returns:
+            Path to the downloaded attachment.
+        """
+        attachment_content = attachment.get()
+        new_path = target_directory / str(attachment.filename)
+
+        with open(new_path, "wb") as file:
+            file.write(attachment_content)
+
+        return new_path
+
+    @retry(exceptions=jira.JIRAError, tries=3, delay=1)
+    def _get_issue(self, issue_key: str) -> jira.Issue:
+        """Retrieves a Jira issue by its key.
+
+        Args:
+            issue_key: The key of the Jira issue.
+
+        Returns:
+            The retrieved Jira issue.
+        """
+        return self._jira_client.issue(issue_key)
+
+    @staticmethod
+    def _get_attachment(issue: jira.Issue, attachment_filename: str):
+        """Gets an attachment from a Jira issue by its filename.
+
+        Args:
+            issue: The Jira issue object.
+            attachment_filename: Filename of the attachment.
+
+        Returns:
+            The attachment object.
+        """
+        found_attachment = None
+        for attachment in issue.fields.attachment:
+            if attachment.filename == attachment_filename:
+                found_attachment = attachment
+                break
+
+        if found_attachment is None:
+            raise Exception(f"target attachment ({attachment_filename}) was not found in: {issue.key}")
+
+        return found_attachment
+
+    def _get_attachment_from_issue(self, issue_key: str, attachment_file_name: str, target_directory: Path) -> Path:
+        """Retrieves and downloads an attachment from a Jira issue.
+
+        Args:
+            issue_key: The key of the Jira issue.
+            attachment_file_name: Filename of the attachment.
+            target_directory: Directory where the attachment should be saved.
+
+        Returns:
+            Path to the downloaded attachment.
+        """
+        issue = self._get_issue(issue_key=issue_key)
+        attachment = self._get_attachment(issue=issue, attachment_filename=attachment_file_name)
+        return self._download_attachment(attachment=attachment, target_directory=target_directory)
+
+    def get(self, glob_pattern: Optional[str] = None, mode: str = "r", from_extracted_tar: bool = False):
+        """Retrieves the item matching the given glob pattern from the downloaded archive. If a non-archive attachment was downloaded, returns its content instead.
+
+        Args:
+            glob_pattern: A global command pattern of the target directory/file. Default is None.
+            mode: The format in which we would like to get the data. Default is 'r'.
+            from_extracted_tar: Whether to retrieve from the extracted tar. Default is False.
+
+        Returns:
+            - The content of the file if the pattern matches a file.
+            - The path of the directory if the pattern matches a directory.
+
+        Raises:
+            FileNotFoundError: If the given pattern doesn't match any file/directory or attachment was not extracted.
+        """
+        if self.downloaded and not self._is_tar_file:
+            return self._local_nested_archive_extractor.get_item(item_path=self._archive_path, mode=mode)
+
+        # if we don't want to get the file from the tar's extraction, or we didn't extract it or the extraction failed,
+        # we want to get the file by from the tar, not tar's extraction.
+        if not from_extracted_tar or not self._extract_tar or not self.extracted:
+            target_virtual_path = self._archive_path / Path(glob_pattern)
+            return nestedarchive.get(nested_archive_path=target_virtual_path, mode=mode)
+
+        glob_pattern = self._local_nested_archive_extractor.remove_interior_tar_or_gzip_extensions(glob_pattern)
+        self._logger.debug(f"glob_pattern: {glob_pattern}")
+
+        matches = list(self.temporary_extracted_archive_path.rglob(glob_pattern))
+        self._logger.debug(f"for pattern ({glob_pattern}) inside {self._archive_path.name} found matches:")
+
+        self._logger.debug("matches:")
+        for match in matches:
+            self._logger.debug(str(match))
+
+        match len(matches):
+            case 0:
+                raise FileNotFoundError(
+                    f"the given pattern ({glob_pattern}) doesn't match in the nested archive {self._archive_path.name}"
+                )
+            case _:
+                return self._local_nested_archive_extractor.get_item(item_path=matches[0], mode=mode)

--- a/tools/triage/utils/extraction/jira_attachment_querier/local_nested_archive_extractor.py
+++ b/tools/triage/utils/extraction/jira_attachment_querier/local_nested_archive_extractor.py
@@ -1,0 +1,161 @@
+import gzip
+import re
+import shutil
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import final
+
+
+@final
+class LocalNestedArchiveExtractor:
+    """Handles the extraction of nested tar archives on a local filesystem."""
+
+    TAR_SUFFIX_PATTERN = re.compile(r"\.tar(\.gz|\.bz2|\.xz)?$")
+    TAR_GZIP_SUFFIXES: frozenset[str] = frozenset({".tar", ".gz"})
+
+    def remove_tar_and_gzip_extensions_if_any(self, file_path: str) -> str:
+        """Strip tar and gzip extensions from a given file path, if present.
+
+        Args:
+            file_path: The file path to process.
+
+        Returns:
+            The file path without tar and gzip extensions.
+        """
+        file_path_ = Path(file_path)
+        while file_path_.suffix in self.TAR_GZIP_SUFFIXES:
+            file_path_ = Path(file_path_.stem)
+
+        return str(file_path_)
+
+    def is_tar_file(self, file_path: Path) -> bool:
+        """Determine if the given path corresponds to a tar file.
+
+        Args:
+            file_path: The file path to check.
+
+        Returns:
+            True if it's a tar file, False otherwise.
+        """
+        return self.TAR_SUFFIX_PATTERN.search(file_path.name) is not None
+
+    def get_item(self, item_path: Path, mode: str) -> str | bytes | Path:
+        """Retrieve the item's content based on the specified mode, or directory path if it is a dirctory.
+
+        Args:
+            item_path: The path to the item.
+            mode: Mode in which to fetch the item's content. Acceptable modes are "r" (read as text) or "rb" (read as bytes).
+
+        Returns:
+            - The content of the file if the provided path points to a file, based on the mode provided.
+            - The path itself if the provided path points to a directory.
+
+        Raises:
+            ValueError: If an unsupported mode is provided.
+        """
+        if item_path.is_dir():
+            return item_path
+
+        match mode:
+            case "rb":
+                return item_path.read_bytes()
+            case "r":
+                return item_path.read_text()
+            case _:
+                raise ValueError("given mode must be one of ['r', 'rb']")
+
+    def convert_directory_to_json(self, directory_path: Path) -> str:
+        """Convert a directory's metadata into a list of JSON like dictionaries.
+
+        Args:
+            directory_path: Path to the directory.
+
+        Returns:
+            A JSON representation (as dictionary) of the directory's metadata.
+        """
+        data = []
+        for file in directory_path.iterdir():
+            file_info = {
+                "name": file.name,
+                "type": "directory" if file.is_dir() else "file",
+                "mtime": datetime.utcfromtimestamp((file.stat().st_mtime)).strftime("%a, %d %b %Y %H:%M:%S GMT"),
+                "size": file.stat().st_size,
+            }
+
+            data.append(file_info)
+
+        return data
+
+    def decompress_gzip(self, gzip_path: Path, target_path: Path):
+        """Decompress a gzip file to a target path.
+
+        Args:
+            gzip_path: Path to the gzip file.
+            target_path: Path where the decompressed file will be saved.
+        """
+        with gzip.open(gzip_path, "rb") as gzip_file:
+            with open(target_path, "wb") as target_file:
+                shutil.copyfileobj(gzip_file, target_file)
+
+    def recursive_extraction(self, source: Path, target: Path, root_tar_path: Path):
+        """Recursively extract archives, including tarballs and gzip files.
+
+        Args:
+            source: Source path to begin extraction from.
+            target: Target directory where the contents will be extracted.
+            root_tar_path: The root tar path to handle nested extractions.
+        """
+
+        if source.is_dir():
+            for child in source.iterdir():
+                if not target.exists():
+                    shutil.copytree(src=child, target=target)
+                self.recursive_extraction(
+                    source=child,
+                    target=target / self.remove_tar_and_gzip_extensions_if_any(child.name),
+                    root_tar_path=root_tar_path,
+                )
+            return
+
+        if self.is_tar_file(source):
+            target.mkdir(parents=True, exist_ok=True)
+
+            with tarfile.open(source) as archive:
+                archive.extractall(target)
+
+            if not source == root_tar_path:
+                source.unlink()
+
+            for child in target.iterdir():
+                self.recursive_extraction(
+                    source=child,
+                    target=target / self.remove_tar_and_gzip_extensions_if_any(child.name),
+                    root_tar_path=root_tar_path,
+                )
+            return
+
+        if source.suffix == ".gz":
+            decompressed_path = target.with_suffix(target.suffix.replace(".gz", ""))
+            self.decompress_gzip(gzip_path=source, target_path=decompressed_path)
+            source.unlink()
+            self.recursive_extraction(source=decompressed_path, target=target, root_tar_path=root_tar_path)
+            return
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            shutil.copy2(src=source, dst=target.parent)
+
+    def remove_interior_tar_or_gzip_extensions(self, file: str) -> str:
+        """Remove tar and gzip extensions within a file path, excluding the last part of the path.
+
+        Args:
+            file: The file path.
+
+        Returns:
+            File path with tar and gzip extensions removed.
+        """
+        file_path = Path(file)
+        file_name = file_path.name
+        file_parent_path = str(file_path.parent)
+        return f"{self.remove_tar_and_gzip_extensions_if_any(file_parent_path)}/{file_name}"


### PR DESCRIPTION
Currently, we use an `NFS` server, which requires `VPN` access to retrieve the data needed for producing the triage signatures. As we plan to transition our runtimes from Jenkins to an environment where `VPN` access might not be feasible, we want to adapt the system to get data from `Jira` attachments instead.

test pipelines :

- http://assisted-jenkins.usersys.redhat.com/job/test-download-logs/45/console  # with Jira
- http://assisted-jenkins.usersys.redhat.com/job/test-download-logs/46/console # with logs server