### PR TITLE
NO-ISSUE: Fix inactive watchers removal

### DIFF
--- a/tools/triage/clean_old_issues.py
+++ b/tools/triage/clean_old_issues.py
@@ -80,6 +80,8 @@ def update_issues(jira_client: jira.JIRA, issues: list[jira.Issue], logger: logg
 
     for issue in issues:
         for watcher in apply_function_with_retry(jira_client.watchers, issue).watchers:
+            if not watcher.active:
+                continue
             try:
                 apply_function_with_retry(jira_client.remove_watcher, issue.key, watcher.name)
                 logger.debug(f"Removed watcher {watcher.name} from issue {issue.key}.")


### PR DESCRIPTION
While removing watchers from old issues, `Jira` client raises an exception if the watcher is not active. We want to eliminate this so it we won't get false alarms. 